### PR TITLE
LLVM Clang format tool entry. Set the style required, run and forget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Projects in Swift language will be marked with :🔶: feel free to add your proj
 
 
 # Style Guides
+* [LLVM Clang Format tool](http://clang.llvm.org/docs/ClangFormat.html) - Life's short, don't waste your time doing machine's work.  Obj-C/C/C++ auto-formatter tool, just run through and forget.  Come with LLVM, Google, Chromium, Mozilla, WebKit styles; see -style flag.
 * [NY Times - Objective C Style Guide](https://github.com/NYTimes/objective-c-style-guide) - The Objective-C Style Guide used by The New York Times.
 * [raywenderlich Style Guide](https://github.com/raywenderlich/objective-c-style-guide) - A style guide that outlines the coding conventions for raywenderlich.com.
 * [Github Objective-C Style Guide](https://github.com/github/objective-c-style-guide) - Style guide & coding conventions for Objective-C projects.


### PR DESCRIPTION
I think this is a very important tool. If adopted, this tool will both save you on the time to read the style guide and applying the style guide. It come with LLVM, Google, Chromium, Mozilla, WebKit styles out of the box. 