### PR TITLE
-Add JumpMarks to Xcode plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Projects in Swift language will be marked with :🔶: feel free to add your proj
  * [RTImageAssets](https://github.com/rickytan/RTImageAssets) - A Xcode plugin to automatically generate all the App icons needed.
  * [BBUncrustifyPlugin-Xcode](https://github.com/benoitsan/BBUncrustifyPlugin-Xcode) - Xcode plugin to format source code using ClangFormat or Uncrustify.
  * [Aviator](https://github.com/marksands/Aviator) - Xcode plugin that brings ⇧⌘T (source/test toggle) from AppCode over to Xcode.
+ * [JumpMarks](https://github.com/merrickp/JumpMarks) - Navigate your code files with numbered bookmarks.
 
 ### Package Manager
  * [Alcatraz](http://alcatraz.io/) - The package manager for Xcode.


### PR DESCRIPTION
This Xcode plugin allows for easy navigation of code files as documented in https://github.com/merrickp/JumpMarks
