### PR TITLE
Remove empty (and duplicate) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  - [Getting Started](#getting-started)
  - [Library and Frameworks](#libraries-and-frameworks)
      - [Audio](#audio)
-     - [Bluetooth](#bluetooth)
      - [Cache](#cache)
      - [Core Data](#core-data)
      - [Charts](#charts)


### PR DESCRIPTION
Content list have one section duplicated that is the Bluetooth section.
This section already is in Hardware section. Furthermore, the first one was empty.