### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
 
 ### Code Quality
  * [KZBootstrap](https://github.com/krzysztofzablocki/KZBootstrap) - Set of scripts and annotations that generate extra compile time errors and warnings on bad code quality.
- * [KZAsserts](https://github.com/krzysztofzablocki/KZAsserts) - Set of custom assertions that automatically generate NSError's, allow for both Assertions in Debug and Error handling in Release builds, with beatiful DSL.
+ * [KZAsserts](https://github.com/krzysztofzablocki/KZAsserts) - Set of custom assertions that automatically generate NSError's, allow for both Assertions in Debug and Error handling in Release builds, with beautiful DSL.
  * [PSPDFUIKitMainThreadGuard](https://gist.github.com/steipete/5664345) - Simple snippet generating assertions when UIKit is used on background threads.
  * [Flex](https://github.com/Flipboard/FLEX) - An in-app debugging and exploration tool for iOS.
  * [chisel](https://github.com/facebook/chisel) - Collection of LLDB commands to assist debugging iOS apps.


### PR DESCRIPTION
@vsouza, I've corrected a typographical error in the documentation of the [awesome-ios](https://github.com/vsouza/awesome-ios) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.