### PR TITLE
Add Provisioning Quick Look plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  * [Localize-Swift](https://github.com/marmelroy/Localize-Swift) - Swift 2.0 friendly localization and i18n with in-app language switching :large_orange_diamond:
  * [Blade](https://github.com/jondot/blade) - Generate Xcode image catalogs for iOS / OSX app icons, universal images, and more.
  * [Retini](https://github.com/terwanerik/Retini) - A super simple retina (2x, 3x) image converter.
+ * [Provisioning](https://github.com/chockenberry/Provisioning) - A Quick Look plug-in to preview .mobileprovision files.
 
 # Rapid Development
  * [KZPlayground](https://github.com/krzysztofzablocki/KZPlayground) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
This is really handy for inspecting a .mobileprovision file (includes the entitlements, provisioned device UDIDs, developer certificates)