### PR TITLE
Add documentation generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  * [Provisioning](https://github.com/chockenberry/Provisioning) - A Quick Look plug-in to preview .mobileprovision files.
  * [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
  * [SwiftGen](https://github.com/AliSoftware/SwiftGen) - A collection of Swift tools to generate Swift code (enums for your assets, storyboards, Localizable.strings, …) :large_orange_diamond:
+ * [Jazzy](https://github.com/realm/jazzy) - Soulful docs for Swift & Objective-C.
 
 # Rapid Development
  * [KZPlayground](https://github.com/krzysztofzablocki/KZPlayground) - Playgrounds for Objective-C for extremely fast prototyping / learning.

--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  * [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
  * [SwiftGen](https://github.com/AliSoftware/SwiftGen) - A collection of Swift tools to generate Swift code (enums for your assets, storyboards, Localizable.strings, …) :large_orange_diamond:
  * [Jazzy](https://github.com/realm/jazzy) - Soulful docs for Swift & Objective-C.
+ * [appledoc](https://github.com/tomaz/appledoc) - ObjectiveC code Apple style documentation set generator.
 
 # Rapid Development
  * [KZPlayground](https://github.com/krzysztofzablocki/KZPlayground) - Playgrounds for Objective-C for extremely fast prototyping / learning.

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  * [Provisioning](https://github.com/chockenberry/Provisioning) - A Quick Look plug-in to preview .mobileprovision files.
  * [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
  * [SwiftGen](https://github.com/AliSoftware/SwiftGen) - A collection of Swift tools to generate Swift code (enums for your assets, storyboards, Localizable.strings, …) :large_orange_diamond:
- * [Jazzy](https://github.com/realm/jazzy) - Soulful docs for Swift & Objective-C.
+ * [Jazzy](https://github.com/realm/jazzy) - Soulful docs for Swift & Objective-C. :large_orange_diamond:
  * [appledoc](https://github.com/tomaz/appledoc) - ObjectiveC code Apple style documentation set generator.
 
 # Rapid Development


### PR DESCRIPTION
This adds [Jazzy](https://github.com/realm/jazzy) and [appledoc](https://github.com/tomaz/appledoc) to the Tools category.