### PR TITLE
Add Functional Programming category and some projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
     - [HUD](#hud)
     - [EventBus](#eventbus)
     - [Files](#files)
+    - [Functional Programming] (functional-programming)
     - [JSON](#json)
     - [Layout](#layout)
     - [Logging](#logging)
@@ -233,6 +234,8 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
 
 ### Files
 * [FileKit](https://github.com/nvzqz/FileKit) - Simple and expressive file management in Swift. :large_orange_diamond:
+
+### Functional Programming
 
 ### JSON
  * [JSONKit](https://github.com/johnezang/JSONKit) - Objective-C JSON.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
 * [FileKit](https://github.com/nvzqz/FileKit) - Simple and expressive file management in Swift. :large_orange_diamond:
 
 ### Functional Programming
+* [Forbind](https://github.com/ulrikdamm/Forbind) - Functional chaining and promises in Swift. :large_orange_diamond:
+* [Funky](https://github.com/brynbellomy/Funky) - Functional programming tools and experiments in Swift. :large_orange_diamond:
+* [LlamaKit](https://github.com/LlamaKit/LlamaKit) - Collection of must-have functional Swift tools. :large_orange_diamond:
+* [Oriole](https://github.com/tptee/Oriole) - A functional utility belt implemented as Swift 2.0 protocol extensions. :large_orange_diamond:
+* [Prelude](https://github.com/robrix/Prelude) - Swift µframework of simple functional programming tools. :large_orange_diamond:
+* [Swiftx](https://github.com/typelift/Swiftx) - Functional data types and functions for any project. :large_orange_diamond:
+* [Swiftz](https://github.com/typelift/Swiftz) -  Functional programming in Swift. :large_orange_diamond:
 
 ### JSON
  * [JSONKit](https://github.com/johnezang/JSONKit) - Objective-C JSON.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
     - [HUD](#hud)
     - [EventBus](#eventbus)
     - [Files](#files)
-    - [Functional Programming] (functional-programming)
+    - [Functional Programming] (#functional-programming)
     - [JSON](#json)
     - [Layout](#layout)
     - [Logging](#logging)


### PR DESCRIPTION
As the [functional buzz grows](https://medium.com/@jugoncalves/functional-programming-should-be-your-1-priority-for-2015-47dd4641d6b9#.h0onvdntx) it is very common to see nowadays people who have been wondering what functional programming is all about but can't find the right resources.

Swift makes it easy to leverage many of the concepts behind functional programming in a pragmatic way - and there are many libs which aim to help our lives by using functional programming in Swift. So I think it is important to have this category.

In this PR I've also added the following libs: 

* Forbind
* Funky
* LlamaKit
* Oriole
* Prelude
* Swiftx
* Swiftz