### PR TITLE
Add Taylor to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ Projects in Swift language will be marked with :large_orange_diamond: and :watch
  * [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
  * [Jazzy](https://github.com/realm/jazzy) - Soulful docs for Swift & Objective-C. :large_orange_diamond:
  * [appledoc](https://github.com/tomaz/appledoc) - ObjectiveC code Apple style documentation set generator.
+ * [Taylor](https://github.com/yopeso/Taylor) - Measure Swift code metrics. :large_orange_diamond:
 
 # Rapid Development
  * [KZPlayground](https://github.com/krzysztofzablocki/KZPlayground) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
Taylor is a tool which measure Swift code metrics.
It can be used to display warnings in Xcode or to generate reports for Jenkins and other CI platforms.