### PR TITLE
Add AELog and AEConsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
  * [Colors](https://github.com/icodeforlove/Colors) - A pure Swift library for using ANSI codes. Basically makes command-line coloring and styling very easy! :large_orange_diamond:[e]
  * [Loggerithm](https://github.com/honghaoz/Loggerithm) - A lightweight Swift logger, uses `print` in development and `NSLog` in production. Support colourful and formatted output. :large_orange_diamond:
  * [CleanroomASL](https://github.com/emaloney/CleanroomASL) - A Swift-based API for reading from & writing to the Apple System Log (more commonly known somewhat inaccurately as "the console") :large_orange_diamond:
+ * [AELog](https://github.com/tadija/AELog) - Simple, lightweight and flexible debug logging framework written in Swift. :large_orange_diamond:
+ * [AEConsole](https://github.com/tadija/AEConsole) - Customizable Console UI overlay with debug log on top of your iOS App. :large_orange_diamond:
 
 ### Maps
  * [Route-me](https://github.com/route-me/route-me) - Open source map library for iOS.


### PR DESCRIPTION
## Project URL
https://github.com/tadija/AELog
https://github.com/tadija/AEConsole

## Description
I've added AELog - Minimalistic but flexible logging approach in Swift and AEConsole - which is displaying debug log from AELog in Console UI overlay on top of any app. (both under Logging). 

## Checklist:
- [ ] One project per pull request
- [ ] `Travis CI` pass