### PR TITLE
Add TextAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ Most of these are paid services, some have free tiers.
  * [SwiftString](https://github.com/amayne/SwiftString) - A comprehensive, lightweight string extension for Swift :large_orange_diamond:[e]
  * [Marklight](https://github.com/macteo/Marklight) - Markdown syntax highlighter for iOS :large_orange_diamond:
  * [MarkdownTextView](https://github.com/indragiek/MarkdownTextView) - Rich Markdown editing control for iOS :large_orange_diamond:
+ * [TextAttributes](https://github.com/delba/TextAttributes) - An easier way to compose attributed strings. :large_orange_diamond:
 
 ##### Font
  * [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app. :large_orange_diamond:


### PR DESCRIPTION
Add `TextAttributes` under the `Text` category.

**Project URL:** [TextAttributes](https://github.com/delba/TextAttributes)

**TextAttributes** makes it easy to compose attributed strings.

```swift
let attrs = TextAttributes()
    .font(name: "HelveticaNeue", size: 16)
    .foregroundColor(white: 0.2, alpha: 1)
    .lineHeightMultiple(1.5)

NSAttributedString("The quick brown fox jumps over the lazy dog", attributes: attrs)
```