### PR TITLE
Add MMSegmentSlider UI control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ Most of these are paid services, some have free tiers.
  * [MARKRangeSlider](https://github.com/vadymmarkov/MARKRangeSlider) - A custom reusable slider control with 2 thumbs (range slider).
  * [ASValueTrackingSlider](https://github.com/alskipp/ASValueTrackingSlider) - A UISlider subclass that displays the slider value in a popup view
  * [TTRangeSlider](https://github.com/TomThorpe/TTRangeSlider) - A slider, similar in style to UISlider, but which allows you to pick a minimum and maximum range.
- * [MMSegmentSlider](https://github.com/MedvedevMax/MMSegmentSlider) - An easy-to-use animated segment slider with IBDesignable support
+ * [MMSegmentSlider](https://github.com/MedvedevMax/MMSegmentSlider) - An easy-to-use customizable animated segment slider for iOS
 
 ##### Stepper
  * [PFStepper](https://github.com/PerfectFreeze/PFStepper) - May be the most elegant stepper you have ever had! :large_orange_diamond:

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ Most of these are paid services, some have free tiers.
  * [MARKRangeSlider](https://github.com/vadymmarkov/MARKRangeSlider) - A custom reusable slider control with 2 thumbs (range slider).
  * [ASValueTrackingSlider](https://github.com/alskipp/ASValueTrackingSlider) - A UISlider subclass that displays the slider value in a popup view
  * [TTRangeSlider](https://github.com/TomThorpe/TTRangeSlider) - A slider, similar in style to UISlider, but which allows you to pick a minimum and maximum range.
+ * [MMSegmentSlider](https://github.com/MedvedevMax/MMSegmentSlider) - An easy-to-use animated segment slider with IBDesignable support
 
 ##### Stepper
  * [PFStepper](https://github.com/PerfectFreeze/PFStepper) - May be the most elegant stepper you have ever had! :large_orange_diamond:


### PR DESCRIPTION
## Project URL
https://github.com/MedvedevMax/MMSegmentSlider

## Description
MMSegmentSlider is an easy-to-use IBDesignable animated segment-slider control for iOS 7+.

## Checklist
- [x] Only one project is in the request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 and later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English