### PR TITLE
Added FBRetainCycleDetector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
  * [MLeaksFinder](https://github.com/Zepo/MLeaksFinder) - Find memory leaks in your iOS app at develop time.
  * [HeapInspector-for-iOS](https://github.com/tapwork/HeapInspector-for-iOS) - Find memory issues & leaks in your iOS app without instruments
  * [FBMemoryProfiler](https://github.com/facebook/FBMemoryProfiler) - iOS tool that helps with profiling iOS Memory usage.
+ * [FBRetainCycleDetector](https://github.com/facebook/FBRetainCycleDetector) - iOS library to help detecting retain cycles in runtime.
 
 ### Color
 * [Chameleon](https://github.com/ViccAlexander/Chameleon) - A lightweight, yet powerful, flat color framework for iOS (ObjC & Swift). :large_orange_diamond:


### PR DESCRIPTION
Added FBRetainCycleDetector.

## Project URL
https://github.com/facebook/FBRetainCycleDetector

## Description
iOS library to help detecting retain cycles in runtime.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project is in the request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 and later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
