### PR TITLE
Add RPFloatingPlaceholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ Most of these are paid services, some have free tiers.
  * [VMaskTextField](https://github.com/viniciusmo/VMaskTextField) - VMaskTextField is a library which create an input mask for iOS.
  * [TJTextField](https://github.com/tejas-ardeshna/TJTextField) - UITextField with underline and left image :large_orange_diamond:
  * [NextGrowingTextView](https://github.com/muukii/NextGrowingTextView) - The next in the generations of 'growing textviews' optimized for iOS 7 and above.
+ * [RPFloatingPlaceholders](https://github.com/iwasrobbed/RPFloatingPlaceholders) - UITextField and UITextView subclasses with placeholders that change into floating labels when the fields are populated with text.
 
 ### Utility
   * [Underscore.m](https://github.com/robb/Underscore.m) - A DSL for Data Manipulation.


### PR DESCRIPTION
## Project URL
https://github.com/iwasrobbed/RPFloatingPlaceholders

## Description
UITextField and UITextView subclasses with placeholders that change into floating labels when the fields are populated with text.

## Checklist
- [x] Only one project is in the request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English