### PR TITLE
Add ADChromePullToRefresh under UI/Pull To Refresh 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,7 @@ Most of these are paid services, some have free tiers.
  * [CBStoreHouseRefreshControl](https://github.com/coolbeet/CBStoreHouseRefreshControl) - Fully customizable pull-to-refresh control inspired by Storehouse iOS app 
  * [SurfingRefreshControl](https://github.com/peiweichen/SurfingRefreshControl) - Inspired by CBStoreHouseRefreshControl.Customizable pull-to-refresh control,written in pure Swift :large_orange_diamond:
  * [mntpulltoreact](https://github.com/mentionapp/mntpulltoreact) - One gesture, many actions. An evolution of Pull to Refresh.
+ * [ADChromePullToRefresh](https://github.com/Antondomashnev/ADChromePullToRefresh) - Chrome iOS app style pull to refresh with multiple actions.
 
 ##### Rating Stars
  * [FloatRatingView](https://github.com/glenyi/FloatRatingView) - Whole, half or floating point ratings control written in Swift :large_orange_diamond:


### PR DESCRIPTION
This PR is related to issue #882

## Project URL
https://github.com/Antondomashnev/ADChromePullToRefresh

## Description
Adding the chrome iOS app style to the list of custom pull to refresh. Supports iOS >=8.0

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

