### PR TITLE
Added NoOptionalInterpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,7 @@ Most of these are paid services, some have free tiers.
  * [SZMentions](https://github.com/szweier/SZMentions) - Library to help handle mentions
  * [SZMentionsSwift](https://github.com/szweier/SZMentionsSwift) - Library to help handle mentions, written in Swift 🔶
  * [Heimdall](https://github.com/henrinormak/Heimdall) - Heimdall is a wrapper around the Security framework for simple encryption/decryption operations. :large_orange_diamond:
+ * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in Swift's string interpolation.🔶[e]
 
 ##### Font
  * [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app. :large_orange_diamond:


### PR DESCRIPTION
Added 'NoOptionalInterpolation' to the 'Text' section.

## Project URL
https://github.com/T-Pham/NoOptionalInterpolation

## Description
Added 'NoOptionalInterpolation' to the 'Text' section.
NoOptionalInterpolation is a Swift extension to ensure the text "Optional(...)" and "nil" are always removed in Swift's string interpolation. It also provides an operator to revert back to the default behaviour.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Only one project is in this pull request
- [x ] Addition in chronological order (bottom of category)
- [x ] `Travis CI` pass
- [x ] Supports iOS 7 or later
- [x ] Has a commit from less than 2 years ago
- [x ] Has a **clear** README in English
