### PR TITLE
Added UITextField-Navigation to the TextField & TextView section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,7 @@ Most of these are paid services, some have free tiers.
  * [RPFloatingPlaceholders](https://github.com/iwasrobbed/RPFloatingPlaceholders) - UITextField and UITextView subclasses with placeholders that change into floating labels when the fields are populated with text.
  * [SRKControls](https://github.com/sag333ar/SRKControls) - A Custom control which turns UITextfield to item-picker & date-picker. :large_orange_diamond:
  * [CurrencyTextField](https://github.com/richa008/CurrencyTextField) - UITextField that automatically formats text to display in the currency format. :large_orange_diamond:
+ * [UITextField-Navigation](https://github.com/T-Pham/UITextField-Navigation) - UITextField-Navigation adds next, previous and done buttons to the keyboard for your UITextFields.🔶[e]
 
 ### Utility
   * [Underscore.m](https://github.com/robb/Underscore.m) - A DSL for Data Manipulation.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/T-Pham/UITextField-Navigation

## Description
<!--- Describe your changes in detail -->
Added UITextField-Navigation to the TextField & TextView section.
UITextField-Navigation adds next, previous and done buttons to the keyboard for your UITextFields. It allows you to specify a next text field either on the Interface Builder or programmatically. Then, you can access next and previous text fields of each UITextField easily.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [ ] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
