### PR TITLE
Add ISO8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,8 +908,8 @@ Most of these are paid services, some have free tiers.
  * [SZMentionsSwift](https://github.com/szweier/SZMentionsSwift) - Library to help handle mentions, written in Swift 🔶
  * [Heimdall](https://github.com/henrinormak/Heimdall) - Heimdall is a wrapper around the Security framework for simple encryption/decryption operations. :large_orange_diamond:
  * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in Swift's string interpolation.🔶[e]
- * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swift
- * [ISO8601](https://github.com/onmyway133/iso8601) Super lightweight ISO8601 Date Formatter in Swift 
+ * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swif t🔶
+ * [ISO8601](https://github.com/onmyway133/iso8601) Super lightweight ISO8601 Date Formatter in Swift 🔶[e]
 
 ##### Font
  * [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app. :large_orange_diamond:

--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ Most of these are paid services, some have free tiers.
  * [Heimdall](https://github.com/henrinormak/Heimdall) - Heimdall is a wrapper around the Security framework for simple encryption/decryption operations. :large_orange_diamond:
  * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in Swift's string interpolation.🔶[e]
  * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swift
+ * [ISO8601](https://github.com/onmyway133/iso8601) Super lightweight ISO8601 Date Formatter in Swift 
 
 ##### Font
  * [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app. :large_orange_diamond:

--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ Most of these are paid services, some have free tiers.
  * [SZMentionsSwift](https://github.com/szweier/SZMentionsSwift) - Library to help handle mentions, written in Swift 🔶
  * [Heimdall](https://github.com/henrinormak/Heimdall) - Heimdall is a wrapper around the Security framework for simple encryption/decryption operations. :large_orange_diamond:
  * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in Swift's string interpolation.🔶[e]
- * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swif t🔶
+ * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swift
  * [ISO8601](https://github.com/onmyway133/iso8601) Super lightweight ISO8601 Date Formatter in Swift 🔶[e]
 
 ##### Font


### PR DESCRIPTION
## Project URL
https://github.com/onmyway133/iso8601

## Description
Super lightweight ISO8601 Date Formatter in Swift

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Although WWDC 2016 introduced NSISO8601DateFormatter, but it needs iOS 10 support to get it. This is a lightweight solution that works on previous versions as well