### PR TITLE
Update NoOptionalInterpolation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ Most of these are paid services, some have free tiers.
  * [SZMentions](https://github.com/szweier/SZMentions) - Library to help handle mentions
  * [SZMentionsSwift](https://github.com/szweier/SZMentionsSwift) - Library to help handle mentions, written in Swift 🔶
  * [Heimdall](https://github.com/henrinormak/Heimdall) - Heimdall is a wrapper around the Security framework for simple encryption/decryption operations. :large_orange_diamond:
- * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - NoOptionalInterpolation gets rid of "Optional(...)" and "nil" in Swift's string interpolation.🔶[e]
+ * [NoOptionalInterpolation](https://github.com/T-Pham/NoOptionalInterpolation) - Get rid of "Optional(...)" and "nil" in string interpolation. Easy pluralization.🔶[e]
  * [Smile](https://github.com/onmyway133/Smile) 😄 Emoji in Swift
 
 ##### Font


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/T-Pham/NoOptionalInterpolation

## Description
<!--- Describe your changes in detail -->
Update the description of NoOptionalInterpolation since the pod has been updated to version 2 with support for pluralization.

```swift
let age = 42
let text = "I am \(age ~ "year") old" // "I am 42 years old"
```

See more [here](https://github.com/T-Pham/NoOptionalInterpolation#pluralization).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [ ] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
