### PR TITLE
FileProvider addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Zip](https://github.com/marmelroy/Zip) - Swift framework for zipping and unzipping files. :large_orange_diamond:
 * [FileBrowser](https://github.com/marmelroy/FileBrowser) - Powerful Swift file browser for iOS. :large_orange_diamond:
 * [Ares](https://github.com/indragiek/Ares) - Zero-setup P2P file transfer between Macs and iOS devices :large_orange_diamond:
+* [FileProvider](https://github.com/amosavian/FileProvider) - SMB/CIFS/WebDAV etc. for Swift on iOS and MacOS.  :large_orange_diamond:
 
 ### Functional Programming
 * [Forbind](https://github.com/ulrikdamm/Forbind) - Functional chaining and promises in Swift. :large_orange_diamond:


### PR DESCRIPTION
SMB/CIFS/WebDAV etc. for Swift on iOS and MacOS.

## Project URL
[https://github.com/amosavian/FileProvider](https://github.com/amosavian/FileProvider)

## Description
Added FileProvider

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [ ] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
