### PR TITLE
Adding Bugfender, cloud storage for app logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
  * [Logkit](https://github.com/logkit/logkit) - An efficient logging library for OS X, iOS, watchOS, and tvOS – written in Swift. Log to console, file, HTTP service, or your own endpoint. Simple to get started, but smartly customizable :large_orange_diamond:
  * [SwiftTrace](https://github.com/johnno1962/SwiftTrace) - Trace Swift and Objective-C method invocations :large_orange_diamond:
  * [Willow](https://github.com/Nike-Inc/Willow) - Willow is a powerful, yet lightweight logging library written in Swift. :large_orange_diamond:
+ * [Bugfender](https://github.com/bugfender/BugfenderSDK-iOS) - Cloud storage for your app logs. Track user behaviour to find problems in your mobile apps.
 
 ### Maps
  * [Route-me](https://github.com/route-me/route-me) - Open source map library for iOS.


### PR DESCRIPTION
## Project URL
https://github.com/bugfender/BugfenderSDK-iOS

## Description
Adding Bugfender,  cloud storage for your app logs.

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

