### PR TITLE
Suggesting Bugfender Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,6 +1617,7 @@ Most of these are paid services, some have free tiers.
  * [Vinyl](https://github.com/Velhotes/Vinyl) - Network testing à la VCR in Swift :large_orange_diamond:
  * [Fetcher](https://github.com/rob-nash/Fetcher) - Mock paging data with a variable fetch time interval.
  * [Mockit](https://github.com/sabirvirtuoso/Mockit) - A simple mocking framework for Swift, inspired by the famous Mockito for Java :large_orange_diamond:
+ * [Bugfender Live](https://github.com/bugfender/BugfenderLive-iOS) - Stream the screen of an iOS device for live debugging.
 
 # Tools
  * [Shark](https://github.com/kaandedeoglu/Shark) - Swift Script that transforms the .xcassets folder into a type safe enum. :large_orange_diamond:


### PR DESCRIPTION
Bugfender Live streams the screen of the iOS device for live debugging

## Project URL
https://github.com/bugfender/BugfenderLive-iOS

## Description
Suggesting Bugfender Live framework. Honestly I'm a bit hesitant of the category. It could go to Testing, or something like Debugging or Customer support.

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Stream the screen of an iOS device for live debugging