### PR TITLE
add link to SwiftyFORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1208,6 +1208,7 @@ Most of these are paid services, some have free tiers.
  * [YALField](https://github.com/Yalantis/YALField) - Custom Field component with validation for creating easier form-like UI from interface builder.
  * [Former](https://github.com/ra1028/Former) - Former is a fully customizable Swift2 library for easy creating UITableView based form. :large_orange_diamond:
  * [SwiftForms](https://github.com/ortuman/SwiftForms) - A small and lightweight library written in Swift that allows you to easily create forms. :large_orange_diamond:
+ * [SwiftyFORM](https://github.com/neoneye/SwiftyFORM) - Framework for creating forms with validation rules :large_orange_diamond:
  * [APValidators](https://github.com/Alterplay/APValidators) - Codeless solution for form validation in iOS!
  * [Formalist](https://github.com/seedco/Formalist) - Declarative form building framework for iOS :large_orange_diamond:
 

--- a/README.md
+++ b/README.md
@@ -1208,9 +1208,9 @@ Most of these are paid services, some have free tiers.
  * [YALField](https://github.com/Yalantis/YALField) - Custom Field component with validation for creating easier form-like UI from interface builder.
  * [Former](https://github.com/ra1028/Former) - Former is a fully customizable Swift2 library for easy creating UITableView based form. :large_orange_diamond:
  * [SwiftForms](https://github.com/ortuman/SwiftForms) - A small and lightweight library written in Swift that allows you to easily create forms. :large_orange_diamond:
- * [SwiftyFORM](https://github.com/neoneye/SwiftyFORM) - Framework for creating forms with validation rules :large_orange_diamond:
  * [APValidators](https://github.com/Alterplay/APValidators) - Codeless solution for form validation in iOS!
  * [Formalist](https://github.com/seedco/Formalist) - Declarative form building framework for iOS :large_orange_diamond:
+ * [SwiftyFORM](https://github.com/neoneye/SwiftyFORM) - Framework for creating forms with validation rules :large_orange_diamond:
 
 ##### Keyboard
  * [RSKKeyboardAnimationObserver](https://github.com/ruslanskorb/RSKKeyboardAnimationObserver) - Showing / dismissing keyboard animation in simple UIViewController category.


### PR DESCRIPTION
Added link to SwiftyFORM, a form framework for iOS written in Swift.

## Project URL

https://github.com/neoneye/SwiftyFORM

## Description

Inserted a single line with the link and a description of what it does.

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

