### PR TITLE
Add HTPullToRefresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ Most of these are paid services, some have free tiers.
 * [ADChromePullToRefresh](https://github.com/Antondomashnev/ADChromePullToRefresh) - Chrome iOS app style pull to refresh with multiple actions.
 * [BreakOutToRefresh](https://github.com/dasdom/BreakOutToRefresh) - A playable pull to refresh view using SpriteKit. :large_orange_diamond:
 * [MJRefresh](https://github.com/CoderMJLee/MJRefresh) An easy way to use pull-to-refresh.
+* [HTPullToRefresh](https://github.com/hoang-tran/HTPullToRefresh) - Easily add vertical and horizontal pull to refresh to any UIScrollView. Can also add multiple pull-to-refesh views at once.
 
 ##### Rating Stars
 * [FloatRatingView](https://github.com/glenyi/FloatRatingView) - Whole, half or floating point ratings control written in Swift :large_orange_diamond:


### PR DESCRIPTION
Add pod HTPullToRefresh.

## Project URL
https://github.com/hoang-tran/HTPullToRefresh

## Description
There is no pod that supports horizontal pull to refresh capability so I made one. It also supports adding multiple pull to refresh views into one single UIScrollView.

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [ ] `Travis CI` pass
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

