### PR TITLE
Add CuckooAlert on Alert View

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,7 @@ Most of these are paid services, some have free tiers.
  * [Toast-Swift](https://github.com/scalessec/Toast-Swift) - A Swift extension that adds toast notifications to the UIView object class. :large_orange_diamond:
  * [PMAlertController](https://github.com/Codeido/PMAlertController) - PMAlertController is a great and customizable substitute to UIAlertController. 🔶
  * [PopupViewController](https://github.com/dimillian/PopupViewController) - UIAlertController drop in replacement with much more customization. 🔶
+ * [CuckooAlert](https://github.com/singcodes/CuckooAlert) - Allow multiple use of presentViewController to UIAlertController. 🔶 
 
 ##### Button
  * [SSBouncyButton](https://github.com/StyleShare/SSBouncyButton) - iOS7-style bouncy button UI component.


### PR DESCRIPTION
add CuckooAlert on Alert View section.

## Project URL
https://github.com/singcodes/CuckooAlert

## Description
Using method swizzling, make multiple UIAlertControllers can use presentViewController for on view controller. 

## Checklist
- [x] Only one project is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
- [x] `Travis CI` pass

