### PR TITLE
Add PSPDFKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [PDFGenerator](https://github.com/sgr-ksmt/PDFGenerator) - A simple Generator of PDF in Swift. Generate PDF from view(s) or image(s). :large_orange_diamond:
 * [SimplePDF](https://github.com/nRewik/SimplePDF) - Create a simple PDF effortlessly. :large_orange_diamond:
 * [SwiftPDFGenerator](https://github.com/kayoslab/SwiftPDFGenerator) - PDF generator using UIViews; Swift Version of 'UIView 2 PDF'. :large_orange_diamond:
+* [PSPDFKit](https://pspdfkit.com/) - Render PDF, add/edit annotations, fill forms, add/edit pages, view/create digital signatures.
 
 ### Messaging
 


### PR DESCRIPTION
## Project URL
https://pspdfkit.com

## Description
Adds a link to PSPDFKit, the leading PDF Framework for iOS, Android and the Web. It is used in Box, Dropbox, Evernote and countless other apps. It is commercial and not open source, see changelog entries here: https://pspdfkit.com/changelog/ios/

PSPDFKit allows to render PDF, add/edit annotations, fill forms, add/edit pages, view/create digital signatures and much more.

I carefully studied the CONTRIBUTING page to ensure that commercial frameworks are allowed as well. The guidelines are not completely clear though - is an additional [Paid] notice required?

Thanks for curating this awesome list!

## Checklist
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 7 or later
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English