### PR TITLE
Add VHBoomMenuButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,6 +1381,7 @@ Most of these are paid services, some have free tiers.
 * [Context-Menu.iOS](https://github.com/Yalantis/Context-Menu.iOS) - You can easily add awesome animated context menu to your app.
 * [ViewDeck](https://github.com/ViewDeck/ViewDeck) - An implementation of the sliding functionality found in the Path 2.0 or Facebook iOS apps.
 * [FrostedSidebar](https://github.com/edekhayser/FrostedSidebar) - Hamburger Menu using Swift and iOS 8 API's :large_orange_diamond:
+* [VHBoomMenuButton](https://github.com/Nightonke/VHBoomMenuButton) - A menu which can ... BOOM!
 
 ##### Modal Transition
 * [BlurryModalSegue](https://github.com/Citrrus/BlurryModalSegue) - A custom modal segue for providing a blurred overlay effect.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [WXWaveView](https://github.com/WelkinXie/WXWaveView) - Add a pretty water wave to your view.
 * [Twinkle](https://github.com/piemonte/Twinkle) - :sparkles: Swift and easy way to make elements in your iOS and tvOS app twinkle :large_orange_diamond:
 * [MotionBlur](https://github.com/fastred/MotionBlur) - MotionBlur allows you to add motion blur effect to iOS animations.
+* [VHBoomMenuButton](https://github.com/Nightonke/VHBoomMenuButton) - A menu which can ... BOOM!
 
 ### Apple TV
 * [Voucher](https://github.com/rsattar/Voucher) - A simple library to make authenticating tvOS apps easy via their iOS counterparts.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [WXWaveView](https://github.com/WelkinXie/WXWaveView) - Add a pretty water wave to your view.
 * [Twinkle](https://github.com/piemonte/Twinkle) - :sparkles: Swift and easy way to make elements in your iOS and tvOS app twinkle :large_orange_diamond:
 * [MotionBlur](https://github.com/fastred/MotionBlur) - MotionBlur allows you to add motion blur effect to iOS animations.
-* [VHBoomMenuButton](https://github.com/Nightonke/VHBoomMenuButton) - A menu which can ... BOOM!
 
 ### Apple TV
 * [Voucher](https://github.com/rsattar/Voucher) - A simple library to make authenticating tvOS apps easy via their iOS counterparts.


### PR DESCRIPTION
VHBoomMenuButton

## Project URL
https://github.com/Nightonke/VHBoomMenuButton

## Description
A menu which can ... BOOM! VHBoomMenuButton is a button of menu. When VHBoomMenuButton is clicked, all its sub-buttons boom out just like a menu.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Addition in chronological order (bottom of category)
- [x] Only one project/change is in this pull request
- [x] Supports iOS 7 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

