### PR TITLE
add SwiftGraph & SwiftPriorityQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [EKAlgorithms](https://github.com/EvgenyKarkan/EKAlgorithms) - Some well known CS algorithms & data structures in Objective-C.
 * [Monaka](https://github.com/naru-jpn/Monaka) - Convert custom struct and fundamental values to NSData.
 * [Buffer](https://github.com/alexdrone/Buffer) - Swift μ-framework for efficient array diffs, collection observation and cell configuration. :large_orange_diamond:
+* [SwiftGraph](https://github.com/davecom/SwiftGraph) - Graph data structure and utility functions in pure Swift. :large_orange_diamond:
+* [SwiftPriorityQueue](https://github.com/davecom/SwiftPriorityQueue) - A priority queue with a classic binary heap implementation in pure Swift. :large_orange_diamond:
 
 ## Date & Time
 


### PR DESCRIPTION
One of these projects uses the other and since they are in the same category, I felt it may be okay to submit them togethers.

## Project URLs
https://github.com/davecom/SwiftGraph
https://github.com/davecom/SwiftPriorityQueue

## Description
These are data structure projects that provide common data structures to Swift programmers not available in the Swift Standard Library.

## Checklist
- [ ] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 8 or later
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
