### PR TITLE
Add AudioIndicatorBars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,6 +1402,7 @@ Most of these are paid services, some have free tiers.
 * [PageControls](https://github.com/popwarsweet/PageControls) - This is a selection of custom page controls to replace UIPageControl, inspired by a dribbble found here :large_orange_diamond:
 * [SwiftSpinner](https://github.com/icanzilb/SwiftSpinner) - A beautiful activity indicator and modal alert written in Swift using blur effects, translucency, flat and bold design :large_orange_diamond:
 * [SnapTimer](https://github.com/andresinaka/SnapTimer) - Implementation of Snapchat's stories timer. :large_orange_diamond:
+* [AudioIndicatorBars](https://github.com/LeonardoCardoso/AudioIndicatorBars) - AIB indicates for your app users which audio is playing. Just like the Podcasts app. :large_orange_diamond:
 
 #### Alerts
 


### PR DESCRIPTION
## Project URL
https://github.com/LeonardoCardoso/AudioIndicatorBars

## Description
Indicates for your app users which audio is playing. Just like the Podcasts app.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 8 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
