### PR TITLE
Fixed buddybuild URL which pointed to a 404 page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1997,7 +1997,7 @@ Most of these are paid services, some have free tiers.
 * [fastlane](https://github.com/fastlane/fastlane) - Connect all iOS deployment tools into one streamlined workflow.
 * [deliver](https://github.com/fastlane/fastlane/tree/master/deliver) - Upload screenshots, metadata and your app to the App Store using a single command.
 * [snapshot](https://github.com/fastlane/fastlane/tree/master/snapshot) Automate taking localized screenshots of your iOS app on every device.
-* [buddybuild](buddybuild.com) - A mobile iteration platform - build, deploy, and collaborate.
+* [buddybuild](https://buddybuild.com/) - A mobile iteration platform - build, deploy, and collaborate.
 * [Bitrise](https://www.bitrise.io) Mobile Continuous Integration & Delivery with dozens of integrations to build, test, deploy and collaborate.
 * [watchbuild](https://github.com/fastlane/fastlane/tree/master/watchbuild) - Get a notification once your iTunes Connect build is finished processing.
 * [Crashlytics](https://try.crashlytics.com/) - A crash reporting and beta testing service.


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [ ] Supports iOS 8 or later
- [ ] Supports Swift 3
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

