### PR TITLE
Add AFNetworking+RetryPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,7 @@ Also see [push notifications](#push-notifications)
 * [MMLanScan](https://github.com/mavris/MMLanScan) - An iOS LAN Network Scanner library
 * [Domainer](https://github.com/FelixLinBH/Domainer) - Manage multi-domain url auto mapping ip address table
 * [Restofire](https://github.com/Restofire/Restofire) - Restofire is a protocol oriented network abstraction layer in swift that is built on top of Alamofire to use services in a declartive way :large_orange_diamond:
+* [AFNetworking+RetryPolicy](https://github.com/kubatruhlar/AFNetworking-RetryPolicy) - An objective-c category that adds the ability to set the retry logic for requests made with AFNetworking.
 
 #### Email
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/kubatruhlar/AFNetworking-RetryPolicy

## Description
Adds the ability to set the retry logic for requests made with AFNetworking.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 8 or later
- [ ] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Add AFNetworking+RetryPolicy to Networking section