### PR TITLE
Fix spelling mistake (HandyJSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ Also see [push notifications](#push-notifications)
 * [AlamofireObjectMapper](https://github.com/tristanhimmelman/AlamofireObjectMapper) - An Alamofire extension which converts JSON response data into swift objects using ObjectMapper :large_orange_diamond:
 * [GuardedSwiftyJSON](https://github.com/wiggzz/GuardedSwiftyJSON) - An add-on to SwiftyJSON to make it easier to create failable initalizers for data models. :large_orange_diamond:
 * [JAYSON](https://github.com/muukii/JAYSON) - Strict and Scalable JSON library. :large_orange_diamond:
-* [HandyJSON](https://github.com/alibaba/handyjson) - A handy swift JSON-object serialization/deserialization libary for swift 2.x/3.x. :large_orange_diamond:
+* [HandyJSON](https://github.com/alibaba/handyjson) - A handy swift JSON-object serialization/deserialization library for swift 2.x/3.x. :large_orange_diamond:
 
 #### XML & HTML
 * [AEXML](https://github.com/tadija/AEXML) - Simple and lightweight XML parser written in Swift. :large_orange_diamond:


### PR DESCRIPTION
A simple spelling mistake fix (`libary` -> `library`)


