### PR TITLE
Added LTHRadioButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,6 +1392,7 @@ Most of these are paid services, some have free tiers.
 * [HubFramework](https://github.com/spotify/HubFramework) - Spotify’s component-driven UI framework for iOS.
 * [ConfettiView](https://github.com/OrRon/ConfettiView) - Confetti View lets you create a magnificent confetti view in your app :large_orange_diamond:
 * [BouncyPageViewController](https://github.com/BohdanOrlov/BouncyPageViewController) - Page view controller with bounce effect :large_orange_diamond:
+* [LTHRadioButton](https://github.com/rolandleth/LTHRadioButton) - A radio button with a pretty fill animation. :large_orange_diamond:
 
 #### Activity Indicator
 


### PR DESCRIPTION
## Project URL
https://github.com/rolandleth/LTHRadioButton

## Description
A radio button with a pretty fill animation, slightly inspired by Google Material's one.
 
## Why it should be included to `awesome-ios` (optional)
I am not aware of any radio buttons, at least not with pretty animations.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Not sure if I should've added `by @rolandleth` to the commit, I just saw a lot of them in the history. Let me know if I should remove it, or if anything else is required. 👋