### PR TITLE
add CSS3ColorsSwift

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [PrettyColors](https://github.com/jdhealy/PrettyColors) - PrettyColors is a Swift library for styling and coloring text in the Terminal. The library outputs [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) and conforms to [ECMA Standard 48](http://www.ecma-international.org/publications/standards/Ecma-048.htm). :large_orange_diamond:
 * [TFTColor](https://github.com/burhanuddin353/TFTColor) - Simple Extension for RGB and CMKY Hex Strings and Hex Values (ObjC & Swift). :large_orange_diamond:
 * [CostumeKit](https://github.com/jakemarsh/CostumeKit) - Base types for theming an app. :large_orange_diamond:
+* [CSS3ColorsSwift](https://github.com/WorldDownTown/CSS3ColorsSwift) - A UIColor extension with CSS3 Colors name. :large_orange_diamond:
 
 ## Command Line
 * [Swiftline](https://github.com/oarrabi/Swiftline) - Swiftline is a set of tools to help you create command line applications. :large_orange_diamond:


### PR DESCRIPTION
add CSS3ColorsSwift

## Project URL
https://github.com/WorldDownTown/CSS3ColorsSwift

## Description
A UIColor extension with CSS3 Colors name.
 
## Why it should be included to `awesome-ios` (optional)
Because this library is simpler than other similar libraries. and you can write web color like UIColor in Swift 3.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
