### PR TITLE
Added Jasonette - ios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,7 @@ Most of these are paid services, some have free tiers.
 * [ReduxSwift](https://github.com/lsunsi/ReduxSwift) - Predictable state container for Swift apps too. :large_orange_diamond:
 * [Aftermath](https://github.com/hyperoslo/Aftermath) - Stateless message-driven micro-framework in Swift. :large_orange_diamond:
 * [RxKeyboard](https://github.com/RxSwiftCommunity/RxKeyboard) - Reactive Keyboard in iOS. :large_orange_diamond:
+* [JASONETTE-iOS](https://github.com/Jasonette/JASONETTE-iOS) - Native App over HTTP. Create your own native iOS app with nothing but JSON.
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
JASONETTE-iOS

## Project URL
https://github.com/Jasonette/JASONETTE-iOS

## Description
Native App over HTTP. Create your own native iOS app with nothing but JSON.
 
It was useful library and I thought it needs to added to awesome swift. But I don't know where it comes, so I added under reactive programming.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 or later
- [ ] Supports Swift 3
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
