### PR TITLE
Add Katana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,6 +1049,7 @@ Most of these are paid services, some have free tiers.
 * [Aftermath](https://github.com/hyperoslo/Aftermath) - Stateless message-driven micro-framework in Swift. :large_orange_diamond:
 * [RxKeyboard](https://github.com/RxSwiftCommunity/RxKeyboard) - Reactive Keyboard in iOS. :large_orange_diamond:
 * [JASONETTE-iOS](https://github.com/Jasonette/JASONETTE-iOS) - Native App over HTTP. Create your own native iOS app with nothing but JSON.
+* [Katana](https://github.com/BendingSpoons/katana-swift) - Swift apps a la React and Redux. :large_orange_diamond:
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
Add Katana under Reactive Programming category.

## Project URL
https://github.com/BendingSpoons/katana-swift

## Description
I added the Katana framework under the Reactive Programming category
 
## Why it should be included to `awesome-ios` (optional)
We think this could help developers to tackle the complexity of their apps.

## Checklist
- [x ] Only one project/change is in this pull request
- [x ] Addition in chronological order (bottom of category)
- [x ] Supports iOS 9 or later
- [x ] Supports Swift 3
- [x ] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English

