### PR TITLE
Add RMDateSelectionViewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -1507,6 +1507,7 @@ Most of these are paid services, some have free tiers.
 * [FCAlertView](https://github.com/nimati/FCAlertView) - A Flat Customizable AlertView for iOS. (Objective-C)
 * [CDAlertView](https://github.com/candostdagdeviren/CDAlertView) - Highly customizable alert/notification/success/error/alarm popup 🔶
 * [RMActionController](https://github.com/CooperRS/RMActionController) - Present any UIView in an UIAlertController like manner.
+* [RMDateSelectionViewController](https://github.com/CooperRS/RMDateSelectionViewController) - Select a date using UIDatePicker in a UIAlertController like fashion.
 
 #### Badge
 * [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons. :large_orange_diamond:


### PR DESCRIPTION
## Project URL
https://github.com/CooperRS/RMDateSelectionViewController

## Description
Add RMDatSelectionViewController to the list of alerts.
 
## Why it should be included to `awesome-ios` (optional)
RMDateSelectionController allows you to easily present an UIDatePicker in an UIAlertController like fashion. It is very flexible regarding the number of buttons that may be added above or below the UIDatePicker.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
