### PR TITLE
Add RMPickerViewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -1508,6 +1508,7 @@ Most of these are paid services, some have free tiers.
 * [CDAlertView](https://github.com/candostdagdeviren/CDAlertView) - Highly customizable alert/notification/success/error/alarm popup 🔶
 * [RMActionController](https://github.com/CooperRS/RMActionController) - Present any UIView in an UIAlertController like manner.
 * [RMDateSelectionViewController](https://github.com/CooperRS/RMDateSelectionViewController) - Select a date using UIDatePicker in a UIAlertController like fashion.
+* [RMPickerViewController](https://github.com/CooperRS/RMPickerViewController) - Select something using UIPickerView in a UIAlertController like fashion.
 
 #### Badge
 * [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons. :large_orange_diamond:


### PR DESCRIPTION
## Project URL
https://github.com/CooperRS/RMPickerViewController

## Description
Add RMPickerViewController to the list of alerts.
 
## Why it should be included to `awesome-ios` (optional)
RMPickerViewController allows you to easily present an UIPickerView in an UIAlertController like fashion. It is very flexible regarding the number of buttons that may be added above or below the UIPickerView.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
