### PR TITLE
Add Hedwig to Alert View

### DIFF
--- a/README.md
+++ b/README.md
@@ -1511,6 +1511,7 @@ Most of these are paid services, some have free tiers.
 * [RMActionController](https://github.com/CooperRS/RMActionController) - Present any UIView in an UIAlertController like manner.
 * [RMDateSelectionViewController](https://github.com/CooperRS/RMDateSelectionViewController) - Select a date using UIDatePicker in a UIAlertController like fashion.
 * [RMPickerViewController](https://github.com/CooperRS/RMPickerViewController) - Select something using UIPickerView in a UIAlertController like fashion.
+* [Hedwig](https://github.com/Lab111/Hedwig) - Interactive Notification. 🔶
 
 #### Badge
 * [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons. :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Lab111/Hedwig

## Description
Add Hedwig to Alert View.
 
## Why it should be included to `awesome-ios` (optional)
Instead of just showing notification, Hedwig tries to be interactive. When a notification pops up, it will be more efficient and user-friendly if the user is able to handle it directly, especially for sophisticated applications like Facebook. Hedwig currently has a tap gesture recognizer so that you can handle the notification by adding an action to it. You can also customize it by adding views and gesture recognizers to satisfy your needs. Although it seems quite simple at the time, the concept behind is more important, and there are a lot Hedwig can develop in the future for better interaction.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
