### PR TITLE
Update category of 'iOS 10 Day by Day'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2223,6 +2223,7 @@ Most of these are paid services, some have free tiers.
 * [Code Facebook](https://code.facebook.com/ios/)
 * [iOS Cookies](http://www.ioscookies.com/) - A hand curated collection of iOS libraries written in Swift :large_orange_diamond:
 * [Feeds for iOS Developer](https://github.com/rgnlax/Feeds-for-iOS-Developer) - The list of RSS feeds for iOS developers.
+* [iOS10 day-by-day](https://www.shinobicontrols.com/blog/ios-10-day-by-day-index) :large_orange_diamond:
 
 #### UIKit references
 * [iOS Fonts](http://iosfonts.com/)
@@ -2256,7 +2257,6 @@ Most of these are paid services, some have free tiers.
 * [learn-swift](https://github.com/nettlep/learn-swift) - Learn Apple's Swift programming language interactively through these playgrounds. :large_orange_diamond:
 * [Treehouse's iOS Courses and Workshops](https://teamtreehouse.com/library/topic:ios) - Topics for beginner and advanced developers in both Objective-C and Swift.
 * [The Swift Summary Book](https://github.com/jakarmy/swift-summary) - A summary of Apple's Swift language written on Playgrounds. :large_orange_diamond:
-* [iOS 10 Day by Day](https://www.shinobicontrols.com/blog/ios-10-day-by-day-index) :large_orange_diamond:
 * [Hacking With Swift](https://www.hackingwithswift.com) - Learn to code iPhone and iPad apps with 3 Swift tutorials. :large_orange_diamond:
 
 #### iOS UI Template


### PR DESCRIPTION
Update category of 'iOS 10 Day by Day' from 'Tutorials and Keynotes' to 'News, Blogs and more', to match category with 'iOS9-day-by-day' and 'iOS8-day-by-day'