### PR TITLE
Add ISO8859 in Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ Most of these are paid services, some have free tiers.
 * [Apodimark](https://github.com/loiclec/Apodimark) - Fast, flexible markdown parser written in Swift. :large_orange_diamond:
 * [Notepad](https://github.com/ruddfawcett/Notepad) - A fully themeable markdown editor with live syntax highlighting. :large_orange_diamond:
 * [KKStringValidator](https://github.com/krizhanovskii/KKStringValidator) - Fast and simple string validation for IOS. With UITextField extension. :large_orange_diamond:
+* [ISO8859](https://github.com/Cosmo/ISO8859) - 📄⚙ Convert ISO8859 1-16 Encoded Text to String in Swift. Supports iOS, tvOS, watchOS and macOS. :large_orange_diamond:
 
 ## Testing
 


### PR DESCRIPTION
## Project URL
https://github.com/Cosmo/ISO8859

## Description
📄⚙ Convert ISO8859 1-16 Encoded Text to String in Swift. Supports iOS, tvOS, watchOS and macOS.
 
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
