### PR TITLE
Adds Asset Checker safety net

### DIFF
--- a/README.md
+++ b/README.md
@@ -2133,6 +2133,7 @@ Most of these are paid services, some have free tiers.
 * [Nomad](http://nomad-cli.com) - Suite of command line utilities & libraries for sending APNs, create & distribute *.ipa*, verify In-App-Purchase receipt and more.
 * [Cookiecutter](https://github.com/cookiecutter-swift/Framework) - A template for new Swift iOS / tvOS / watchOS / macOS Framework project ready with travis-ci, cocoapods, Carthage, SwiftPM and a Readme file :large_orange_diamond:
 * [Insanity](https://github.com/krzysztofzablocki/Insanity) - A tool that brings meta-programming to Swift, allowing you to code generate Swift code. :large_orange_diamond:
+* [AssetChecker 👮](https://github.com/s4cha/AssetChecker) - Keeps your Assets.xcassets files clean and emits warnings when something is suspicious. :large_orange_diamond:
 
 # Rapid Development
 * [KZPlayground](https://github.com/krzysztofzablocki/KZPlayground) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
## Project URL
https://github.com/s4cha/AssetChecker

## Description
This adds AssetChecker script to the list of tools
 
## Why it should be included to `awesome-ios` (optional)
While solutions like Misen or SwiftGen are great they generate extra swift structs and moves us aways from Apple solution aka image literals. They solve one issue: code breaks when asset disappears, because the corresponding struct does as well. This script does exactly that, while enabling us to use the great and very readable image literals :) Plus it warns when an Asset is not used in the code, great for cleaning long lasting projects.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
