### PR TITLE
Add NSTEasyJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ Also see [push notifications](#push-notifications)
 * [HandyJSON](https://github.com/alibaba/handyjson) - A handy swift JSON-object serialization/deserialization library for swift 2.x/3.x. :large_orange_diamond:
 * [Marshal](https://github.com/utahiosmac/Marshal) - Marshaling the typeless wild west of [String: Any] (Protocol based).
 * [Motis](https://github.com/mobilejazz/Motis) - Easy JSON to NSObject mapping using Cocoa's key value coding (KVC).
+* [NSTEasyJSON](https://github.com/bernikowich/NSTEasyJSON) - The easiest way to deal with JSON data in Objective-C (similar to SwiftyJSON).
 
 #### XML & HTML
 * [AEXML](https://github.com/tadija/AEXML) - Simple and lightweight XML parser written in Swift. :large_orange_diamond:


### PR DESCRIPTION
Was wondering if it was ok to add NSTEasyJSON to the list.
Thanks!

## Project URL
https://github.com/bernikowich/NSTEasyJSON

## Description
There is nothing like SwiftyJSON compatible with Objective-C, but Objective-C is still used by many developers.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
