### PR TITLE
Add Ebblink SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [FacebookImagePicker](https://github.com/terflogag/FacebookImagePicker) - Facebook album photo picker written in Swift. :large_orange_diamond:
 * [Lightbox](https://github.com/hyperoslo/Lightbox) - A convenient and easy to use image viewer for your iOS app. :large_orange_diamond:
 * [AvatarImageView](https://github.com/ayushn21/AvatarImageView) - AvatarImageView is a UIImageView subclass designed to show a user's profile picture, falling back to their initials when a picture is unavailable. :large_orange_diamond:
+* [Ebblink](https://github.com/ebbapp/ebblinkSDK) - An iOS SDK for sharing photos that automatically expire and can be deleted at any time.
 
 #### Media Processing
 * [SwiftOCR](https://github.com/garnele007/SwiftOCR) - Fast and simple OCR library written in Swift :large_orange_diamond:
@@ -867,8 +868,6 @@ Also see [push notifications](#push-notifications)
 * [NMessenger](https://github.com/eBay/NMessenger) - A fast, lightweight messenger component built on AsyncDisplaykit and written in Swift :large_orange_diamond:
 * [Atlas](https://github.com/layerhq/Atlas-iOS) - A library of native iOS messaging user interface components for Layer.
 * [Messenger](https://github.com/relatedcode/Messenger) - This is a native iOS Messenger app, making realtime chat conversations and audio calls with full offline support.
-* * [Ebblink](https://github.com/ebbapp/ebblinkSDK) - An iOS SDK for sharing photos that automatically expire and can be deleted at any time.
-
 
 ## Networking
 * [AFNetworking](https://github.com/AFNetworking/AFNetworking) - A delightful iOS and OS X networking framework.

--- a/README.md
+++ b/README.md
@@ -867,6 +867,8 @@ Also see [push notifications](#push-notifications)
 * [NMessenger](https://github.com/eBay/NMessenger) - A fast, lightweight messenger component built on AsyncDisplaykit and written in Swift :large_orange_diamond:
 * [Atlas](https://github.com/layerhq/Atlas-iOS) - A library of native iOS messaging user interface components for Layer.
 * [Messenger](https://github.com/relatedcode/Messenger) - This is a native iOS Messenger app, making realtime chat conversations and audio calls with full offline support.
+* * [Ebblink](https://github.com/ebbapp/ebblinkSDK) - An iOS SDK for sharing photos that automatically expire and can be deleted at any time.
+
 
 ## Networking
 * [AFNetworking](https://github.com/AFNetworking/AFNetworking) - A delightful iOS and OS X networking framework.


### PR DESCRIPTION
Request to add the _Ebblink SDK_ under _Messaging_

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
[https://github.com/ebbapp/ebblinkSDK](https://github.com/ebbapp/ebblinkSDK)
[http://http://www.fiveopenbooks.com/](http://www.fiveopenbooks.com/)

## Description
<!--- Describe your changes in detail -->
The ebblink SDK makes it possible to share photos that expire automatically (after a customizable period of time has elapsed). These photos can be removed anytime. Photos are encrypted and stored in our servers and can only be accessed by intended recipients (as long as the photos have not expired or have not been removed). A URL or deeplink to these shared images is provided back by the SDK. These links can be shared within a messaging app or posted on social networks. Developers can choose to have a password generated for each photo (so that the URL and the password have to be shared separately) or to embed the password in the URL. 

## Why it should be included to `awesome-ios` (optional)

Encrypted photos with expiration time enhance photo sharing privacy and can be useful in a number of applications, such as messaging, posting on social networks, etc. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
