### PR TITLE
Added MiniTabBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1883,6 +1883,7 @@ Most of these are paid services, some have free tiers.
 * [KYWheelTabController](https://github.com/ykyouhei/KYWheelTabController) - KYWheelTabController is a subclass of UITabBarController.It displays the circular menu instead of UITabBar. :large_orange_diamond:
 * [SuperBadges](https://github.com/odedharth/SuperBadges) - Add emojis and colored dots as badges for your Tab Bar buttons 🔶
 * [AZTabBarController](https://github.com/Minitour/AZTabBarController) - A custom tab bar controller for iOS written in Swift 3.0 🔶
+* [MiniTabBar](https://github.com/D-32/MiniTabBar) - A clean simple alternative to the UITabBar 🔶
 
 #### Table View / Collection View
 * [MGSwipeTableCell](https://github.com/MortimerGoro/MGSwipeTableCell) - UITableViewCell subclass that allows to display swippable buttons with a variety of transitions.


### PR DESCRIPTION
## Project URL
https://github.com/D-32/MiniTabBar

## Description
A clean simple alternative to the UITabBar. Only shows the title when being tapped on. Gives the app a way cleaner look :)
 
## Why it should be included to `awesome-ios` (optional)
I think other developers can also profit from it.

## Checklist
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 9 or later
- [X] Supports Swift 3
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
