### PR TITLE
Add CalendarKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1649,6 +1649,7 @@ Most of these are paid services, some have free tiers.
 * [Koyomi](https://github.com/shoheiyokoyama/Koyomi) - Simple customizable calendar component in Swift :large_orange_diamond:
 * [DateTimePicker](https://github.com/itsmeichigo/DateTimePicker) - A nicer iOS UI component for picking date and time :large_orange_diamond:
 * [RCalendarPicker](https://github.com/roycms/RCalendarPicker) - RCalendarPicker A date picker control.
+* [CalendarKit](https://github.com/richardtop/CalendarKit) - Fully customizable calendar day view. :large_orange_diamond:
 
 #### Form & Settings
 * [Form](https://github.com/hyperoslo/Form) - The most flexible and powerful way to build a form on iOS


### PR DESCRIPTION
## Project URL
https://github.com/richardtop/CalendarKit

## Description
CalendarKit is a fully customizable calendar library written in Swift. It was designed to look similar to iOS Calendar app out-of-the-box, but allow complete customization when needed. To make modifications easy, CalendarKit is composed of multiple small modules. They can be used together, or on their own.
 
## Why it should be included to `awesome-ios` (optional)
Because there is no such library here yet.

## Checklist
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 9 or later
- [X] Supports Swift 3
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
