### PR TITLE
Add Reactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Most of these are paid services, some have free tiers.
 * [TemplateKit](https://github.com/mcudich/TemplateKit) - React-inspired framework for building component-based user interfaces in Swift. :large_orange_diamond:
 * [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) - Streams of values over time by ReactiveCocoa group
 * [Listenable](https://github.com/MerrickSapsford/Listenable) - Swift object that provides an observable platform. :large_orange_diamond:
+* [Reactor](https://github.com/ReactorSwift/Reactor) - :arrows_counterclockwise: Unidirectional Data Flow using idiomatic Swift—inspired by Elm and Redux . :large_orange_diamond:
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
Adds [Reactor](https://github.com/ReactorSwift/Reactor) to the Reactive Programming section.

Reactor is a framework inspired by Elm and Redux that brings unidirectional data flow patterns in a more idiomatic Swift manner.

## Project URL
[https://github.com/ReactorSwift/Reactor](https://github.com/ReactorSwift/Reactor)

## Description
Adds Reactor to the end of the Reactive Programming section.
 
## Why it should be included to `awesome-ios` (optional)

Because it _is_ awesome. 😄
There are several Elm and Redux inspired patterns, but Reactor approaches it in a way that I believe is more idiomatic Swift.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
