### PR TITLE
Add snail to reactive programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,6 +1068,7 @@ Most of these are paid services, some have free tiers.
 * [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) - Streams of values over time by ReactiveCocoa group
 * [Listenable](https://github.com/MerrickSapsford/Listenable) - Swift object that provides an observable platform. :large_orange_diamond:
 * [Reactor](https://github.com/ReactorSwift/Reactor) - :arrows_counterclockwise: Unidirectional Data Flow using idiomatic Swift—inspired by Elm and Redux . :large_orange_diamond:
+* [Snail](https://github.com/UrbanCompass/Snail) - An observables framework for Swift :large_orange_diamond:
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/UrbanCompass/Snail

## Description
An observables framework for Swift. Was created as a simple alternative to some of the larger projects like RxSwift.
 
## Why it should be included to `awesome-ios` (optional)
Snail is super useful for almost all swift projects that want to leverage observables. Here are just a few projects that are currently using Snail:
  - Mextures (https://itunes.apple.com/us/app/mextures/id650415564?mt=8)
  - Vellum (https://itunes.apple.com/us/app/vellum-artistic-wallpapers/id1095068317?mt=8)
  - Compass / (https://itunes.apple.com/us/app/compass-real-estate-homes/id692766504?mt=8)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
