### PR TITLE
Add swift-project-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2340,6 +2340,7 @@ Most of these are paid services, some have free tiers.
 * [dsnip](https://github.com/Tintenklecks/IBDelegateCodesippets) - Tool to generate (native) Xcode code snippets from all protocols/delegate methods of UIKit (UITableView, ...)
 * [SBShortcutMenuSimulator](https://github.com/DeskConnect/SBShortcutMenuSimulator) - 3D Touch shortcuts in the Simulator
 * [awesome-gitignore-templates](https://github.com/aashishtamsya/awesome-gitignore-templates) - A collection of swift, objective-c, android and many more langugages .gitignore templates 📝.
+* [swift-project-template](https://github.com/artemnovichkov/swift-project-template) - Template for iOS Swift project generation.
 
 # Reference
 * [Swift Cheat Sheet](https://github.com/iwasrobbed/Swift-CheatSheet) - A quick reference cheat sheet for common, high level topics in Swift. :large_orange_diamond:


### PR DESCRIPTION
Cookiecutter template for an Swift iOS project.

## Project URL
https://github.com/artemnovichkov/swift-project-template

## Description
Simple and useful template for generation of Swift project with just two commands.
 
## Why it should be included to `awesome-ios` (optional)

I don't see any tools or examples of templates for projects. It's good tool that help you save your time.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English