### PR TITLE
Add Pageboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,6 +1514,7 @@ Most of these are paid services, some have free tiers.
 * [YLProgressBar](https://github.com/yannickl/YLProgressBar) - UIProgressView replacement with an highly and fully customizable animated progress bar in pure Core Graphics.
 * [FlexibleSteppedProgressBar](https://github.com/amratab/FlexibleSteppedProgressBar) - A beautiful easily customisable stepped progress bar.  :large_orange_diamond:
 * [GradientLoadingBar](https://github.com/fxm90/GradientLoadingBar) - An animated gradient loading bar. :large_orange_diamond:
+* [Pageboy](https://github.com/MerrickSapsford/Pageboy) - A simple, highly informative page view controller. :large_orange_diamond:
 
 #### Animation
 * [Pop](https://github.com/facebook/pop) - An extensible iOS and OS X animation library, useful for physics-based interactions.


### PR DESCRIPTION
Added Pageboy

## Project URL
https://github.com/MerrickSapsford/Pageboy

## Description
Pageboy is a simple, highly informative page view controller. A drop in replacement wrapper for UIPageViewController; it provides more reliable, precise delegation and additional features.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English