### PR TITLE
Added 'Swiftly Salesforce' to SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,7 +1146,7 @@ Most of these are paid services, some have free tiers.
 * [RandomUserSwift](https://github.com/dingwilson/RandomUserSwift) - Swift 3 Framework to Generate Random Users - An Unofficial SDK for randomuser.me :large_orange_diamond:
 * [PPEventRegistryAPI](https://github.com/pantuspavel/PPEventRegistryAPI/) - Swift 3 Framework for Event Registry API (eventregistry.org). :large_orange_diamond:
 * [UnsplashKit](https://github.com/carambalabs/UnsplashKit) - Swift client for Unsplash. :large_orange_diamond:
-* [Swiftly Salesforce](https://github.com/mike4aday/SwiftlySalesforce) - Build native iOS apps fast on the Salesforce Platform with Swift and promises. :large_orange_diamond:
+* [Swiftly Salesforce](https://github.com/mike4aday/SwiftlySalesforce) - Build native iOS apps fast on the [Salesforce Platform](https://www.salesforce.com/products/platform/overview/) with Swift and promises. :large_orange_diamond:
 
 ## Security
 * [cocoapods-keys](https://github.com/orta/cocoapods-keys) - A key value store for storing environment and application keys.

--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ Most of these are paid services, some have free tiers.
 * [RandomUserSwift](https://github.com/dingwilson/RandomUserSwift) - Swift 3 Framework to Generate Random Users - An Unofficial SDK for randomuser.me :large_orange_diamond:
 * [PPEventRegistryAPI](https://github.com/pantuspavel/PPEventRegistryAPI/) - Swift 3 Framework for Event Registry API (eventregistry.org). :large_orange_diamond:
 * [UnsplashKit](https://github.com/carambalabs/UnsplashKit) - Swift client for Unsplash. :large_orange_diamond:
+* [Swiftly Salesforce](https://github.com/mike4aday/SwiftlySalesforce) - Build native iOS apps fast on the Salesforce Platform with Swift and promises. :large_orange_diamond:
 
 ## Security
 * [cocoapods-keys](https://github.com/orta/cocoapods-keys) - A key value store for storing environment and application keys.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/mike4aday/SwiftlySalesforce

## Description
Added 'Swiftly Salesforce' as the last entry under 'SDK / Unofficial.'
 
## Why it should be included to `awesome-ios` (optional)
'Swiftly Salesforce' is a Swift 3 framework that makes it easy to build native iOS apps that integrate with the Salesforce Platform.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English