### PR TITLE
Add tvOS to PRs template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Only one project/change is in this pull request
 - [ ] Addition in chronological order (bottom of category)
-- [ ] Supports iOS 9 / tvOS 9 / or later
+- [ ] Supports iOS 9 / tvOS 10 or later
 - [ ] Supports Swift 3
 - [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,8 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Only one project/change is in this pull request
 - [ ] Addition in chronological order (bottom of category)
-- [ ] Supports iOS 9 / tvOS 10 or later
+- [ ] Supports iOS 9 or later
+- [ ] Supports tvOS 10 or later
 - [ ] Supports Swift 3
 - [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Only one project/change is in this pull request
 - [ ] Addition in chronological order (bottom of category)
-- [ ] Supports iOS 9 or later
+- [ ] Supports iOS 9 / tvOS 9 / or later
 - [ ] Supports Swift 3
 - [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,7 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Only one project/change is in this pull request
 - [ ] Addition in chronological order (bottom of category)
-- [ ] Supports iOS 9 or later
-- [ ] Supports tvOS 10 or later
+- [ ] Supports iOS 9 / tvOS 10 or later
 - [ ] Supports Swift 3
 - [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English


### PR DESCRIPTION

I recently sent a couple of PR for AppleTv projects and I had to mark the following checklist element:

- [ ] Supports iOS 9 or later

This PR adds tvOS to make it a bit more flexible for this type of projects

- [ ] Supports iOS 9 / tvOS 10 or later

