### PR TITLE
Add Atributika in Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ Most of these are paid services, some have free tiers.
 * [Mustard](https://github.com/mathewsanders/Mustard) - Mustard is a Swift library for tokenizing strings when splitting by whitespace doesn't cut it. :large_orange_diamond:
 * [Input Mask](https://github.com/RedMadRobot/input-mask-ios) - Pattern-based user input formatter, parser and validator for iOS. :large_orange_diamond:
 * [Attributed](https://github.com/Nirma/Attributed) - A Modern interface for attributed strings. :large_orange_diamond:
+* [Atributika](https://github.com/psharanda/Atributika) - Easily build NSAttributedString by detecting and styling HTML-like tags, hashtags, mentions, RegExp or NSDataDetector patterns. :large_orange_diamond:
 
 ## Testing
 


### PR DESCRIPTION
## Project URL
https://github.com/psharanda/Atributika

## Description
Easily build NSAttributedString by detecting and styling HTML-like tags, hashtags, mentions, RegExp or NSDataDetector patterns

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English