### PR TITLE
Added IGColorPicker in UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ Most of these are paid services, some have free tiers.
 * [PanelKit](https://github.com/louisdh/panelkit) - A UI framework that enables panels on iOS. :large_orange_diamond:
 * [ElongationPreview](https://github.com/Ramotion/elongation-preview) - ElongationPreview is an elegant push-pop style view controller with 3D-Touch support and gestures. :large_orange_diamond:
 * [Pageboy](https://github.com/MerrickSapsford/Pageboy) - A simple, highly informative page view controller. :large_orange_diamond:
+* [IGColorPicker](https://github.com/iGenius-Srl/IGColorPicker) - 🎨 A customizable color picker for iOS in Swift 🔶
 
 #### Activity Indicator
 


### PR DESCRIPTION
Added IGColorPicker in UI section

## Project URL
https://github.com/iGenius-Srl/IGColorPicker

## Description
Added the pod IGColorPicker in the UI section
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English