### PR TITLE
Add WatchNote

### DIFF
--- a/README.md
+++ b/README.md
@@ -2133,6 +2133,8 @@ Most of these are paid services, some have free tiers.
  * [ContactsWrapper](https://github.com/abdullahselek/ContactsWrapper) - Easy to use wrapper for both contacts and contacts group with Objective-C.
  * [XestiMonitors](https://github.com/eBardX/XestiMonitors) - An extensible monitoring framework written in Swift :large_orange_diamond:
  * [OpenSourceController](https://github.com/terflogag/OpenSourceController) - The simplest way to display the librarie's licences used in your application. :large_orange_diamond:
+ * [WatchNote](https://github.com/ezefranca/WatchNote) - ⌚️ 🤓 Controlling your Keynote using Apple Watch. :large_orange_diamond:
+ 
 
 ## VR
 * [VR Toolkit iOS](https://github.com/Aralekk/VR_Toolkit_iOS) - A sample project that provides the basics to create an interactive VR experience on iOS :large_orange_diamond:


### PR DESCRIPTION
Added WatchNote: An app to help you control your slides using iPhone or Apple Watch

## Project URL
https://github.com/ezefranca/WatchNote

## Description
⌚️ 🤓 Controlling your Keynote using Apple Watch
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
