### PR TITLE
add ViperC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2395,6 +2395,7 @@ Most of these are paid services, some have free tiers.
 * [awesome-gitignore-templates](https://github.com/aashishtamsya/awesome-gitignore-templates) - A collection of swift, objective-c, android and many more langugages .gitignore templates 📝.
 * [swift-project-template](https://github.com/artemnovichkov/swift-project-template) - Template for iOS Swift project generation.
 * [Swift-VIPER-Module](https://github.com/Juanpe/Swift-VIPER-Module) - Xcode template for create modules with VIPER Architecture written in Swift 3 :large_orange_diamond:
+* [ViperC](https://github.com/abdullahselek/ViperC) - Xcode template for VIPER Architecture written in Objective-C
 
 # Reference
 * [Swift Cheat Sheet](https://github.com/iwasrobbed/Swift-CheatSheet) - A quick reference cheat sheet for common, high level topics in Swift. :large_orange_diamond:


### PR DESCRIPTION
Xcode template for VIPER Architecture written in Objective-C

## Project URL
https://github.com/abdullahselek/ViperC

## Description
ViperC creates modules for you when you want to use VIPER architecture in your projects
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
