### PR TITLE
Add RangeSeekSlider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1901,6 +1901,7 @@ Most of these are paid services, some have free tiers.
 * [CircularSlider](https://github.com/taglia3/CircularSlider) - A powerful Circular Slider. It's written in Swift, it's 100% IBDesignable and all parameters are IBInspectable. :large_orange_diamond:
 * [HGCircularSlider](https://github.com/HamzaGhazouani/HGCircularSlider) - A custom reusable circular slider control for iOS application. :large_orange_diamond:
 * [PivotSlider](https://github.com/lab111/pivot-slider) - Slider that pivots :large_orange_diamond:
+* [RangeSeekSlider](https://github.com/WorldDownTown/RangeSeekSlider) - A customizable range slider for iOS. :large_orange_diamond:
 
 #### Splash View
 * [CBZSplashView](https://github.com/callumboddy/CBZSplashView) - Twitter style Splash Screen View. Grows to reveal the Initial view behind.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
[RangeSeedSlider](https://github.com/WorldDownTown/RangeSeekSlider)

## Description
A customizable range slider like a UISlider for iOS.
 
## Why it should be included to `awesome-ios` (optional)
This library based on [TTRangeSlider](https://github.com/TomThorpe/TTRangeSlider). This library is fully made with Swift and is compatible Carthage.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English