### PR TITLE
Added ReverseExtension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2031,6 +2031,7 @@ Most of these are paid services, some have free tiers.
 * [EditDistance](https://github.com/kazuhiro4949/EditDistance) - Incremental update tool for UITableView and UICollectionView :large_orange_diamond:
 * [CenteredCollectionView](https://github.com/BenEmdon/CenteredCollectionView) - A lightweight CollectionView that _'pages'_ and _centers_ it's cells 🎡 written in Swift. :large_orange_diamond:
 * [YBSlantedCollectionViewLayout](https://github.com/yacir/YBSlantedCollectionViewLayout) - UICollectionViewLayout with slanted content.
+* [ReverseExtension](https://github.com/marty-suzuki/ReverseExtension) - A UITableView extension that enables cell insertion from the bottom of a table view.
 
 #### Tag
 * [PARTagPicker](https://github.com/paulrolfe/PARTagPicker) - This pod provides a view controller for choosing and creating tags in the style of wordpress or tumblr.


### PR DESCRIPTION
<!--- ReverseExtension -->

## Project URL
<!--- https://github.com/marty-suzuki/ReverseExtension -->

## Description
<!--- A UITableView extension that enables cell insertion from the bottom of a table view. -->
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
