### PR TITLE
Add SwiftySound

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [InteractivePlayerView](https://github.com/AhmettKeskin/InteractivePlayerView) - Custom iOS music player view :large_orange_diamond:
 * [ESTMusicIndicator](https://github.com/Aufree/ESTMusicIndicator) - Cool Animated music indicator view written in Swift :large_orange_diamond:
 * [QuietModemKit](https://github.com/quiet/QuietModemKit) - iOS framework for the Quiet Modem (data over sound)
+* [SwiftySound](https://github.com/adamcichy/SwiftySound) - Super simple library that lets you play sounds with a single line of code (and much more). Written in Swift 3, supports iOS, macOS and tvOS. Cocoapods and Carthage compatible. :large_orange_diamond:
 
 #### GIF
 * [YLGIFImage](https://github.com/liyong03/YLGIFImage) - Async GIF image decoder and Image viewer supporting play GIF images. It just use very less memory.


### PR DESCRIPTION
SwiftySound added.

## Project URL
https://github.com/adamcichy/SwiftySound

## Description
SwiftySound has been added to the Audio section. SwiftySound is a simple library that lets you play sounds with a single line of code.
 
## Why it should be included to `awesome-ios` (optional)
- The simplest way of playing sounds in Swift 3.
- Supports iOS, macOS and tvOS.
- Cocoapods and Carthage compatible.
- Used in my apps, meaning that I will support it in the future.
- Allows playing the same sound multiple times (not possible with pure AVFoundation).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English