### PR TITLE
Adds 'NSLock+Synchronized' to Concurrency libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Brisk](https://github.com/jmfieldman/Brisk) - A Swift DSL that allows concise and effective concurrency manipulation. :large_orange_diamond:
 * [Aojet](https://github.com/aojet/Aojet) - An actor model library for swift.
 * [Overdrive](https://github.com/arikis/Overdrive) - Fast async task based Swift framework with focus on type safety, concurrency and multi threading. :large_orange_diamond:
+* [NSLock+Synchronized](https://github.com/Jon-Schneider/NSLock-Synchronized) - Do you miss @synchronized in Swift? NSLock+Synchronized gives you back @synchronized in Swift via a global function and NSLock class and instance methods, conveniently usable via Cocoapod and Carthage Framework. :large_orange_diamond:[e]
 
 ## Core Data
 * [CWCoreData](https://github.com/jayway/CWCoreData) - Additions and utilities to make it concurrency easier with the Core Data framework.


### PR DESCRIPTION
Adds 'NSLock+Synchronized' to Concurrency libraries.

## Project URL
https://github.com/Jon-Schneider/NSLock-Synchronized

## Description
NSLock+Synchronized gives developers @synchronized functionality in Swift via a global function and NSLock class and instance methods, conveniently usable via Cocoapod and Carthage Framework. 
 
## Why it should be included to `awesome-ios` (optional)
This library gives developers very simple concurrency options when a more substantial approach (like a queue) would be overkill through a familiar interface, as well as more Ruby-like patterns of adding a class and instance synchronized method to the standard lock class.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 9 / tvOS 10 or later
- [X] Supports Swift 3
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English