### PR TITLE
Added CFSA to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Pencil](https://github.com/naru-jpn/pencil) - Write values to file and read it more easily. :large_orange_diamond:
 * [HeckelDiff](https://github.com/mcudich/HeckelDiff) - A fast Swift diffing library. :large_orange_diamond:
 * [Dekoter](https://github.com/artemstepanenko/Dekoter) - `NSCoding`'s counterpart for Swift structs. :large_orange_diamond:
-
+* [Compiler-Friendly-Storyboard-Access](https://github.com/nadav96/compiler-friendly-storyboard-access) - Access and initializate the project Storyboard controllers in a compiler friendly way using structs and enums (instead of hardcoded strings). :large_orange_diamond:
 ## Date & Time
 
 * [Every.swift](https://github.com/samhann/Every.swift) - A swift wrapper for NSTimer  :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
[compiler-friendly-storyboard-access](https://github.com/nadav96/compiler-friendly-storyboard-access/blob/master/README.md)

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `awesome-ios` (optional)
I'm amazed Xcode still forces us to access Storyboards and controllers using raw strings (which could easily result with unexpected runtime exceptions, with a typo for example), this build time python script will scan the project for all storyboard files, and list all the available controllers group by storyboards using enums and structs, no more runtime exceptions in this regard!!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 9 / tvOS 10 or later
- [X] Has a **clear** README in English
- [X] Supports Swift 3
- [X] Has a commit from less than 2 years ago
