### PR TITLE
Add ACKReactiveExtensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ Most of these are paid services, some have free tiers.
 * [Reactor](https://github.com/ReactorSwift/Reactor) - :arrows_counterclockwise: Unidirectional Data Flow using idiomatic Swift—inspired by Elm and Redux . :large_orange_diamond:
 * [Snail](https://github.com/UrbanCompass/Snail) - An observables framework for Swift :large_orange_diamond:
 * [RxWebSocket](https://github.com/fjcaetano/RxWebSocket) - Reactive extension over Starscream for websockets :large_orange_diamond:
+* [ACKReactiveExtensions](https://github.com/AckeeCZ/ACKReactiveExtensions) - Useful extensions for ReactiveCocoa :large_orange_diamond:
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/AckeeCZ/ACKReactiveExtensions

## Description
<!--- Describe your changes in detail -->
Add ACKReactiveExtensions library
 
## Why it should be included to `awesome-ios` (optional)
We (iOS devs) all work with UIKit and many common classes again and again. And those who work with ReactiveSwift and ReactiveCocoa use lot of interesting extension to simplify our job so we thought it would be nice to have place where we can put them all together. So we did.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
