### PR TITLE
Disable Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
   - allowed_redirects=growthpush,awesomelinkcounter,eepurl,bluemix,amazon
   - awesome_bot README.md --allow-ssl --white-list $allowed_dupes,$allowed_redirects
   - danger
+notifications:
+  email: false


### PR DESCRIPTION
This prevents Travis from flooding our inboxes each time someone decides to change a route.
For renames, we have @ReadmeCritic, for anything else we have Danger and reports on each PR.

What do you guys think? 

cc/ @vsouza @dkhamsing @lfarah @nschucky 