### PR TITLE
Add SugarAnchor to Layout category

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Framezilla](https://github.com/Otbivnoe/Framezilla) - Elegant library which wraps working with frames with a nice chaining syntax. :large_orange_diamond:
 * [TinyConstraints](https://github.com/roberthein/TinyConstraints) -  The syntactic sugar that makes Auto Layout sweeter for human use. :large_orange_diamond:
 * [MyLinearLayout](https://github.com/youngsoft/MyLinearLayout) - MyLayout is a powerful iOS UI framework implemented by Objective-C. It integrates the functions with Android Layout,iOS AutoLayout,SizeClass, HTML CSS float and flexbox and bootstrap.
+* [SugarAnchor](https://github.com/ashikahmad/SugarAnchor) - Same native NSLayoutAnchor & NSLayoutConstraints; but with more natural and easy to read syntactic sugar. Typesafe, concise & readable. :large_orange_diamond:
 
 #### Location
 * [IngeoSDK](https://github.com/IngeoSDK/ingeo-ios-sdk) - Always-On Location monitoring framework for iOS.


### PR DESCRIPTION
Added suggestion for SugarAnchor in Layout category

## Project URL
https://github.com/ashikahmad/SugarAnchor

## Description
[SugarAnchor](https://github.com/ashikahmad/SugarAnchor) is added at the bottom of layout category. 
 
## Why it should be included to `awesome-ios` (optional)
Unlike most of other layout-libraries, this microframework (less than 300 LOC) just adds syntactic sugar around NSLayoutAnchor functionalities. This keeps your layout code still native, but more concise and readable.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
