### PR TITLE
Add FanMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,7 @@ Most of these are paid services, some have free tiers.
 * [YNDropDownMenu](https://github.com/younatics/YNDropDownMenu) - Adorable iOS drop down menu with Swift3. :large_orange_diamond:
 * [KWDrawerController](https://github.com/Kawoou/KWDrawerController) - Drawer view controller that easy to use! :large_orange_diamond:
 * [JNDropDownMenu](https://github.com/javalnanda/JNDropDownMenu) - Easy to use tableview style drop down menu with multi-column support written in Swift3. :large_orange_diamond:
+* [FanMenu](https://github.com/exyte/fan-menu) - Menu with a circular layout based on Macaw. :large_orange_diamond:
 
 #### Navigation Bar
 * [HidingNavigationBar](https://github.com/tristanhimmelman/HidingNavigationBar) - Easily hide and show a view controller's navigation bar (and tab bar) as a user scrolls :large_orange_diamond:


### PR DESCRIPTION
Add FanMenu iOS control in Menu section

## Project URL
https://github.com/exyte/fan-menu

## Description
Menu with a circular layout based on Macaw library
 
## Why it should be included to `awesome-ios` (optional)
FanMenu is a good example what control you could build with Macaw.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English


---

*edited*