### PR TITLE
Added Marky Mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,7 @@ Most of these are paid services, some have free tiers.
 * [Guitar](https://github.com/ArtSabintsev/Guitar) - A Cross-Platform String Library Written in Swift. :large_orange_diamond:
 * [RealTimeCurrencyFormatter](https://github.com/kaiomedau/realtime-currency-formatter-objc) - An ObjC international currency formatting utility.
 * [Down](https://github.com/iwasrobbed/Down) - Blazing fast Markdown rendering in Swift, built upon cmark. 🔶
+* [Marky Mark](https://github.com/m2mobi/Marky-Mark) - Highly customizable Markdown parsing and native rendering in Swift. 🔶
 
 ## Testing
 


### PR DESCRIPTION
Added Markymark library to the 'Text' category

## Project URL
https://github.com/m2mobi/Marky-Mark

## Description
Offers a unique way of parsing and displayed Markdown with many layout possibilities. Can render into native views or plain NSAttributedString. Markdown flavor, layout and rendering can be extended and overwritten to customise the parser into any way needed.

## Why it should be included to `awesome-ios` (optional)
None of the Markdown parsers in the list offer parsing into native layout which is highly customisable, including remote images, nested lists and custom bullets.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
