### PR TITLE
Add LicensePlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2370,6 +2370,7 @@ Most of these are paid services, some have free tiers.
 * [DBDebugToolkit](https://github.com/dbukowski/DBDebugToolkit) - Set of easy to use debugging tools for iOS developers & QA engineers.
 * [Attabench](https://github.com/lorentey/Attabench) - Microbenchmarking app for Swift with nice log-log plots :large_orange_diamond:
 * [Gluten](https://github.com/wilbertliu/Gluten) - Nano library to unify XIB and it's code. :large_orange_diamond:
+* [LicensePlist](https://github.com/mono0926/LicensePlist) - A license list generator of all your dependencies for iOS applications. :large_orange_diamond:
 
 # Rapid Development
 * [Playgrounds](https://github.com/krzysztofzablocki/Playgrounds) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
Added LicensePlist to list of Tools.

## Project URL

https://github.com/mono0926/LicensePlist

## Description

A license list generator of all your dependencies for iOS applications
 
## Why it should be included to `awesome-ios` (optional)

A tool which generates license list automatically can definitely help the iOS community.

## Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English