### PR TITLE
Add Hanson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,7 @@ Most of these are paid services, some have free tiers.
 * [RxWebSocket](https://github.com/fjcaetano/RxWebSocket) - Reactive extension over Starscream for websockets :large_orange_diamond:
 * [ACKReactiveExtensions](https://github.com/AckeeCZ/ACKReactiveExtensions) - Useful extensions for ReactiveCocoa :large_orange_diamond:
 * [ReactiveLocation](https://github.com/AckeeCZ/ReactiveLocation) - CoreLocation made reactive :large_orange_diamond:
+* [Hanson](https://github.com/blendle/Hanson) - Lightweight observations and bindings in Swift, with support for KVO and NotificationCenter. :large_orange_diamond:
 
 ## Reflection
 * [Reflection](https://github.com/Zewo/Reflection) - Reflection provides an API for advanced reflection at runtime including dynamic construction of types. :large_orange_diamond:


### PR DESCRIPTION
Add Hanson to the list of frameworks.

## Project URL
https://github.com/blendle/Hanson

## Description
Hanson is a lightweight framework to support observing and binding values. It's written in Swift, and also offers support for KVO, KVC and NotificationCenter.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
