### PR TITLE
Add InAppSettingsKit to Utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2237,6 +2237,7 @@ Most of these are paid services, some have free tiers.
  * [OpenSourceController](https://github.com/terflogag/OpenSourceController) - The simplest way to display the libraries licences used in your application. :large_orange_diamond:
  * [App-Update-Tracker](https://github.com/Stunner/App-Update-Tracker) - Easily detect and run code upon app installation or update.
  * [ExtensionalSwift](https://github.com/4taras4/SwiftExtension) - Useful swift extensions in one place 🔶[e]
+ * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit) - This iOS framework allows settings to be in-app in addition to or instead of being in the Settings app.
 
 ## VR
 * [VR Toolkit iOS](https://github.com/Aralekk/VR_Toolkit_iOS) - A sample project that provides the basics to create an interactive VR experience on iOS :large_orange_diamond:


### PR DESCRIPTION
Close #993

https://github.com/futuretap/InAppSettingsKit

This iOS framework allows settings to be in-app in addition to or instead of being in the Settings app.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
