### PR TITLE
Added AutoKeyboard for automatic view resizing with keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1836,6 +1836,7 @@ Most of these are paid services, some have free tiers.
 * [MakemojiSDK](https://github.com/makemoji/MakemojiSDK) - Emoji Keyboard SDK (iOS)
 * [Typist](https://github.com/totocaster/Typist) - Small, drop-in Swift UIKit keyboard manager for iOS apps-helps manage keyboard's screen presence and behavior without notification center. :large_orange_diamond:
 * [KeyboardHideManager](https://github.com/bonyadmitr/KeyboardHideManager) - Codeless manager to hide keyboard by tapping on views for iOS written in Swift :large_orange_diamond:
+* [AutoKeyboard](https://github.com/chanonly123/AutoKeyboard) - Automatically update constraints bounded with `bottomLayoutGuide` when the keyboard appears, for iOS written in Swift 3.0 :large_orange_diamond:
 
 #### Label
 * [LTMorphingLabel](https://github.com/lexrus/LTMorphingLabel) - Graceful morphing effects for UILabel written in Swift. :large_orange_diamond:


### PR DESCRIPTION
Added AutoKeyboard library entry in Keyboard section

## Project URL
https://github.com/chanonly123/AutoKeyboard

## Description
Just added AutoKeyboard library entry in Keyboard section
 
## Why it should be included to `awesome-ios` (optional)
It is fully automatic keyboard handling. Like in android no need to resize views when keyboard appears. It updates constraints which are bounded with `bottomLayoutGuide`. Feels like `bottomLayoutGuide` moves up and down with keyboard. Just need to `register` and `unResgister` thats it.

## Checklist
- Supports `Swift 3.0` and above.