### PR TITLE
Add CodableAlamofire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ Most of these are paid services, some have free tiers.
 * [Serpent](https://github.com/nodes-ios/Serpent) - A protocol to serialize Swift structs and classes for encoding and decoding. :large_orange_diamond:
 * [MagicMapper](https://github.com/adrianitech/magic-mapper-swift) - :star2: Super light and easy automatic JSON to model mapper. :large_orange_diamond:
 * [FlatBuffersSwift](https://github.com/mzaks/FlatBuffersSwift) - This project brings FlatBuffers (an efficient cross platform serialization library) to Swift. :large_orange_diamond:
+* [CodableAlamofire](https://github.com/Otbivnoe/CodableAlamofire) - An extension for Alamofire that converts JSON data into Decodable objects (Swift 4). :large_orange_diamond:
 
 #### XML & HTML
 * [AEXML](https://github.com/tadija/AEXML) - Simple and lightweight XML parser written in Swift. :large_orange_diamond:


### PR DESCRIPTION
# CodableAlamofire

## Project URL
https://github.com/Otbivnoe/CodableAlamofire

## Description
*Swift 4 introduces a new Codable protocol that lets you serialize and deserialize custom data types without writing any special code.*

So, I created an extension for Alamofire that converts JSON data into Decodable objects. 🎉
