### PR TITLE
Added Kotlin for Swift Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2529,6 +2529,7 @@ Most of these are paid services, some have free tiers.
 * [Objective-C Cheat Sheet](https://github.com/iwasrobbed/Objective-C-CheatSheet) - A quick reference cheat sheet for common, high level topics in Objective-C.
 * [SwiftSnippets](https://github.com/hyperoslo/SwiftSnippets) - A collection of Swift snippets to be used in Xcode
 * [App Store Checklist](https://github.com/whitef0x0/app-store-checklist) - A checklist of what to look for before submitting your app to the App Store.
+* [Kotlin for Swift Developers](https://github.com/aashishtamsya/Kotlin-for-Swift-Developers) - A project focused on learning Kotlin basics and building a strong Kotlin foundation before jumping into Android Development with Kotlin language.
 
 # Style Guides
 * [NY Times - Objective C Style Guide](https://github.com/NYTimes/objective-c-style-guide) - The Objective-C Style Guide used by The New York Times.


### PR DESCRIPTION
Added Link in Reference Section for a project about **Kotlin Development for Swift Developers**.

## Project URL
[Project URL](https://github.com/aashishtamsya/Kotlin-for-Swift-Developers)

## Description
This project focus only on Kotlin, not Android Application Development with Kotlin. I feel the need to learning Kotlin basics and building a string Kotlin foundation before jumping into Android Development.
 
## Why it should be included to `awesome-ios`

It should be added in awesome-ios so that swift developers will have a hands on starting point to start development in Kotlin which will eventually lead **_Swift Developers to develop for both Android & iOS_**.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
