### PR TITLE
Add Swift mark to PhotoEditorSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [FlexibleImage](https://github.com/kawoou/FlexibleImage) - A simple way to play with image! :large_orange_diamond:
 * [TLPhotoPicker](https://github.com/tilltue/TLPhotoPicker) - Multiple phassets picker for iOS lib. like a facebook. :large_orange_diamond:
 * [YapImageManager](https://github.com/yapstudios/YapImageManager) - A high-performance image downloader written in Swift, powered by YapDatabase. :large_orange_diamond:
-* [PhotoEditorSDK](https://www.photoeditorsdk.com) - A fully customizable photo editor for your app.
+* [PhotoEditorSDK](https://www.photoeditorsdk.com) - A fully customizable photo editor for your app. :large_orange_diamond:
 
 #### Media Processing
 * [SwiftOCR](https://github.com/garnele007/SwiftOCR) - Fast and simple OCR library written in Swift :large_orange_diamond:


### PR DESCRIPTION
## Project URL
https://www.photoeditorsdk.com

## Description
PhotoEditor SDK is written in Swift. This pull requests adds the :large_orange_diamond: mark to reflect this.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English