### PR TITLE
Add McPicker to the list of PickerView’s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1930,6 +1930,7 @@ Most of these are paid services, some have free tiers.
 * [CZPicker](https://github.com/chenzeyu/CZPicker) - A picker view shown as a popup for iOS.
 * [AIDatePickerController](https://github.com/alikaragoz/AIDatePickerController) - :date: UIDatePicker modally presented with iOS 7 custom transitions.
 * [CountryPicker](https://github.com/4taras4/CountryCode) - :date: UIPickerView with Country names flags and phoneCodes 🔶
+* [McPicker](https://github.com/kmcgill88/McPicker-iOS) - A customizable, closure driven UIPickerView drop-in solution with animations that is rotation ready. :large_orange_diamond:
 
 #### Popup
 * [PopupKit](https://github.com/rynecheow/PopupKit) - A simple and flexible class for presenting custom views as a popup in iOS and tvOS, maintained from [KLCPopup](https://github.com/jmascia/KLCPopup).


### PR DESCRIPTION
## Project URL
https://github.com/kmcgill88/McPicker-iOS

## Description
Added McPicker to the list of PickerView’s.
 
## Why it should be included to `awesome-ios` (optional)
I thought the list of picker views was relatively small compared to other categories. None of the pickers currently in the list grabbed my attention so I decided to come up with a solution of my own. All these great libraries have helped me so I want to give back and share McPicker with the world.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English