### PR TITLE
Deleted @NSHipster

### DIFF
--- a/README.md
+++ b/README.md
@@ -2681,7 +2681,6 @@ Most of these are paid services, some have free tiers.
 
 #### Twitter
 * [@objcio](https://twitter.com/objcio)
-* [@nshipster](https://twitter.com/NSHipster)
 * [@CocoaPods](https://twitter.com/CocoaPods)
 * [@CocoaPodsFeed](https://twitter.com/CocoaPodsFeed)
 * [@RubyMotion](https://twitter.com/RubyMotion)


### PR DESCRIPTION
I don't wan't to be mean, but https://twitter.com/NSHipster Twitter has died in 2016 :(
