### PR TITLE
Added ChromaColorPicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [CostumeKit](https://github.com/jakemarsh/CostumeKit) - Base types for theming an app. :large_orange_diamond:
 * [CSS3ColorsSwift](https://github.com/WorldDownTown/CSS3ColorsSwift) - A UIColor extension with CSS3 Colors name. :large_orange_diamond:
 * [Colorify](https://github.com/czater/Colorify) - Simple, yet powerful color library that includes latest and most trendy colors from 2017. :large_orange_diamond:
+* [ChromaColorPicker](https://github.com/joncardasis/ChromaColorPicker) - An intuitive iOS color picker built in Swift. :large_orange_diamond:
 
 ## Command Line
 * [Swiftline](https://github.com/nsomar/Swiftline) - Swiftline is a set of tools to help you create command line applications. :large_orange_diamond:


### PR DESCRIPTION
Added ChromaColorPicker by @joncardasis

## Project URL
https://github.com/joncardasis/ChromaColorPicker

## Description
Added ChromaColorPicker to `Color` section
 
## Why it should be included to `awesome-ios` (optional)
Not many projects are listed which are iOS color pickers

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
