### PR TITLE
Add AnyDate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [TrueTime](https://github.com/instacart/TrueTime.swift) - Get the true current time impervious to device clock time changes. (NTP library for Swift) . :large_orange_diamond:
 * [10Clock](https://github.com/joedaniels29/10Clock) - This Control is a beautiful time-of-day picker heavily inspired by the iOS 10 "Bedtime" timer. :large_orange_diamond:
 * [NSDate-TimeAgo](https://github.com/kevinlawler/NSDate-TimeAgo) - A "time ago", "time since", "relative date", or "fuzzy date" category for NSDate and iOS, Objective-C, Cocoa Touch, iPhone, iPad.
+* [AnyDate](https://github.com/Kawoou/AnyDate) - Swifty Date & Time API inspired from Java 8 DateTime API. :large_orange_diamond:
 
 ## EventBus
 * [SwiftEventBus](https://github.com/cesarferreira/SwiftEventBus) - A publish/subscribe event bus optimized for iOS8. :large_orange_diamond:


### PR DESCRIPTION
Swifty Date & Time API inspired from Java 8 DateTime API.

## Project URL
https://github.com/Kawoou/AnyDate

## Description
Here's the AnyDate, whole new Swift date & time API that has coherence between Java 8.
 
## Why it should be included to `awesome-ios` (optional)
Listed trending a few days ago.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English