### PR TITLE
Added StorageKit under the Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Nora](https://github.com/SD10/Nora) - Nora is a Firebase abstraction layer for working with FirebaseDatabase and FirebaseStorage. :large_orange_diamond:
 * [PersistentStorageSerializable](https://github.com/IvanRublev/PersistentStorageSerializable) - Swift library that makes easier to serialize the user's preferences (app's settings) with system User Defaults or Property List file on disk. :large_orange_diamond:
 * [WCDB](https://github.com/Tencent/wcdb) - WCDB is an efficient, complete, easy-to-use mobile database framework for iOS, macOS.
+* [StorageKit](https://github.com/StorageKit/StorageKit) - Your Data Storage Troubleshooter 🛠
 
 
 ## Data Structures / Algorithms


### PR DESCRIPTION
I've added the project StorageKit under the Database section because it's a layer over Core Data and Realm (so far)

## Project URL
[https://github.com/StorageKit/StorageKit](https://github.com/StorageKit/StorageKit)

## Description
Added StorageKit as latest project under the Databases section
 
## Why it should be included to `awesome-ios`
Because it's an active and fully tested project :P

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English