### PR TITLE
Add Bugsnag to "Analytics"

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Countly](https://count.ly) - Open source, mobile & web analytics, crash reports and push notifications platform for iOS & Android.
 * [Abbi](https://github.com/abbiio/iosdk) - A Simple SDK for developers to manage and maximise conversions of all in-app promotions.
 * [devtodev](https://www.devtodev.com/) - Comprehensive analytics service that improves your project and saves time for product development.
+* [Bugsnag](https://www.bugsnag.com/platforms/ios-crash-reporting/) - Error tracking with a free tier. Error reports include data on device, release, user, and allows arbitrary data.
 
 ## Apple TV
 * [Voucher](https://github.com/rsattar/Voucher) - A simple library to make authenticating tvOS apps easy via their iOS counterparts.


### PR DESCRIPTION
## Project URL

https://www.bugsnag.com/platforms/ios-crash-reporting

## Description

Error tracking with a free tier. Error reports include data on device, release, user, and allows arbitrary data.

## Why it should be included to awesome-ios (optional)

It's got solid support for obj-c & swift, and has a free tier which is useful for small projects. Seems in the same category as Fabric (app behavior analytics)

## Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English (I'm counting its iOS [docs](https://docs.bugsnag.com/platforms/ios/) page, which are in English)