### PR TITLE
Add SwiftQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Threadly](https://github.com/nvzqz/Threadly) - Type-safe thread-local storage in Swift :large_orange_diamond:
 * [Flow-iOS](https://github.com/roytornado/Flow-iOS) - Make your logic flow and data flow clean and human readable :large_orange_diamond:
 * [Queuer](https://github.com/FabrizioBrancati/Queuer) - A queue manager, built on top of OperationQueue and Dispatch (aka GCD). :large_orange_diamond:
+* [SwiftQueue](https://github.com/lucas34/SwiftQueue) - Job Scheduler with Concurrent run, failure/retry, persistence, repeat, delay and more. :large_orange_diamond:
 
 ## Core Data
 * [CWCoreData](https://github.com/jayway/CWCoreData) - Additions and utilities to make it concurrency easier with the Core Data framework.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/lucas34/SwiftQueue

## Description
Job Scheduler with Concurrent run, failure/retry, persistence, repeat, delay and more
 
## Why it should be included to `awesome-ios` (optional)
My requirement was quite simple, run tasks with execution constraints. I couldn't find any library for IOS that can do this easily. Existing libs are all lacking of functionalities. So I decided to make my own, inspired by popular job scheduler's library on android like android-priority-jobqueue or android-job.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [X] Supports iOS 9 / tvOS 10 or later
- [X] Supports Swift 3 or later
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
