### PR TITLE
Add Layout Framework Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [MiniLayout](https://github.com/yonat/MiniLayout) - Minimal AutoLayout convenience layer. Program constraints succinctly. :large_orange_diamond:
 * [Bamboo](https://github.com/wordlessj/Bamboo) - Bamboo makes Auto Layout (and manual layout) elegant and concise. :large_orange_diamond:
 * [FlexLayout](https://github.com/lucdion/FlexLayout) - FlexLayout gently wraps the highly optimized [facebook/yoga](https://github.com/facebook/yoga) flexbox implementation in a concise, intuitive & chainable syntax. 🔶
+* [Layout Framework Benchmark](https://github.com/lucdion/LayoutFrameworkBenchmark) - Benchmark the performances of various Swift layout frameworks. 🔶
 
 #### Location
 * [IngeoSDK](https://github.com/IngeoSDK/ingeo-ios-sdk) - Always-On Location monitoring framework for iOS.


### PR DESCRIPTION
## Project URL
https://github.com/lucdion/LayoutFrameworkBenchmark

## Description
Not a Layout framework, but a benchmark that compares the performance of different Swift layout frameworks.

The benchmark currently includes the following layout frameworks:
* **Auto layout**  
* **Manual layout**  
* [**FlexLayout**](https://github.com/lucdion/FlexLayout)  
* [**LayoutKit**](https://github.com/linkedin/LayoutKit)  
* [**PinLayout**](https://github.com/mirego/PinLayout)  
* **UIStackViews**  
* [**Yoga**](https://github.com/facebook/yoga)  


## Why it should be included to `awesome-ios` (optional)
Choosing the right layout framework for your project is an important decision. The framework API is quite important, but its performance is also important. To help you with that decision, this benchmark compare different layout frameworks.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
