### PR TITLE
Add HoldToSaveImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2271,6 +2271,7 @@ Most of these are paid services, some have free tiers.
 * [SwiftWebVC](https://github.com/meismyles/SwiftWebVC) - A drop-in inline browser for your Swift iOS app. :large_orange_diamond:
 * [SVWebViewController](https://github.com/TransitApp/SVWebViewController) - A drop-in inline browser for your iOS app.
 * [PTPopupWebView](https://github.com/pjocprac/PTPopupWebView) - PTPopupWebView is a simple and useful WebView for iOS, which can be popup and has many of the customized item. :large_orange_diamond:
+* [HoldToSaveImage](https://github.com/theniceboy/HoldToSaveImage) - A UIWebView that allows users to save a image from webview to their photo album with the common gesture: press and hold (long press). 🔶
 
 ## URL Scheme
 * [WAAppRouting](https://github.com/Wasappli/WAAppRouting) - iOS routing done right. Handles both URL recognition and controller displaying with parsed parameters. All in one line, controller stack preserved automatically!


### PR DESCRIPTION
Added HoldToSaveImage

## Project URL
https://github.com/theniceboy/HoldToSaveImage

## Description
A UIWebView that allows users to save a image from webview to their photo album with the common gesture: press and hold (long press).
 
## Why it should be included to `awesome-ios` (optional)
Because it’s helpful!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English