### PR TITLE
added LNPopupController by @LeoNatan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2020,6 +2020,7 @@ Most of these are paid services, some have free tiers.
 * [SelectionDialog](https://github.com/kciter/SelectionDialog) - Simple selection dialog. :large_orange_diamond:
 * [AZDialogViewController](https://github.com/Minitour/AZDialogViewController) - A highly customizable alert dialog controller that mimics Snapchat's alert dialog. :large_orange_diamond:
 * [MIBlurPopup](https://github.com/MarioIannotta/MIBlurPopup) - MIBlurPopup let you create amazing popups with a blurred background.
+* [LNPopupController](https://github.com/LeoNatan/LNPopupController) - a framework for presenting view controllers as popups of other view controllers, much like the Apple Music and Podcasts apps.
 
 #### Pull to Refresh
 * [DGElasticPullToRefresh](https://github.com/gontovnik/DGElasticPullToRefresh) - Elastic pull to refresh for iOS developed in Swift :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/LeoNatan/LNPopupController

## Description
<!--- Describe your changes in detail -->
 added LNPopupController to Popup

## Why it should be included to `awesome-ios` (optional)
It is a popular (1923 stars) lib to present view controllers as popups of other view controllers, much like the Apple Music and Podcasts apps.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x]  Has a **clear** README in English