### PR TITLE
Added ARKit Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 ## ARKit
 * [ARKit-CoreLocation](https://github.com/ProjectDent/ARKit-CoreLocation) -Combines the high accuracy of AR with the scale of GPS data. :large_orange_diamond:
 * [Virtual Objects](https://github.com/ignacio-chiazzo/ARKit) - Placing Virtual Objects in Augmented Reality.
-* [ARKit Navigation](https://github.com/chriswebb09/ARKitNavigationDemo) - Navigation With ARKit and MapKit
+* [ARKit Navigation](https://github.com/chriswebb09/ARKitNavigationDemo) - Navigation With ARKit and MapKit :large_orange_diamond:
 
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Sage](https://github.com/nvzqz/Sage) - A cross-platform chess library for Swift. :large_orange_diamond:
 * [ShogibanKit](https://github.com/codelynx/ShogibanKit) - ShogibanKit is a framework for implementing complex Japanese Chess (Shogii) in Swift. No UI, nor AI. :large_orange_diamond:
 * [SKTiled](https://github.com/mfessenden/SKTiled) - Swift framework for working with Tiled assets in SpriteKit :large_orange_diamond:
-* [BWCollectionView](https://github.com/bwide/BWCollectionView) - A swift framework for a collectionView in SpriteKit :large_orange_diamond:
+* [BWCollectionView](https://github.com/bwide/CollectionNode) - A swift framework for a collectionView in SpriteKit :large_orange_diamond:
 
 ## Gesture
 * [Tactile](https://github.com/delba/Tactile) - A better way to handle gestures on iOS :large_orange_diamond:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 ## ARKit
 * [ARKit-CoreLocation](https://github.com/ProjectDent/ARKit-CoreLocation) -Combines the high accuracy of AR with the scale of GPS data. :large_orange_diamond:
 * [Virtual Objects](https://github.com/ignacio-chiazzo/ARKit) - Placing Virtual Objects in Augmented Reality.
+* [ARKit Navigation](https://github.com/chriswebb09/ARKitNavigationDemo) - Navigation With ARKit and MapKit
+
 
 ## Authentication
 * [Heimdallr.swift](https://github.com/trivago/Heimdallr.swift) - Easy to use OAuth 2 library for iOS, written in Swift. :large_orange_diamond:


### PR DESCRIPTION
Added link to ARKit Navigation project.

## Project URL
[https://github.com/chriswebb09/ARKitNavigationDemo](https://github.com/chriswebb09/ARKitNavigationDemo)

## Description
Adding a new link to awesome-ios.
 
## Why it should be included to `awesome-ios` (optional)
It's an interesting project that doesn't require any pods and is actively maintained. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Only one project/change is in this pull request
- [X] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [X] Supports Swift 3 or later
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English