### PR TITLE
Add WWDC17-Recap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2645,6 +2645,7 @@ Most of these are paid services, some have free tiers.
 * [SwiftSnippets](https://github.com/hyperoslo/SwiftSnippets) - A collection of Swift snippets to be used in Xcode
 * [App Store Checklist](https://github.com/whitef0x0/app-store-checklist) - A checklist of what to look for before submitting your app to the App Store.
 * [whats-new-in-swift-4](https://github.com/ole/whats-new-in-swift-4) - An Xcode playground showcasing the new features in Swift 4.0. :large_orange_diamond:
+* [WWDC17-Recap](https://github.com/erenkabakci/WWDC17-Recap) - Markdown collection repo for the sessions at WWDC17.
 
 # Style Guides
 * [NY Times - Objective C Style Guide](https://github.com/NYTimes/objective-c-style-guide) - The Objective-C Style Guide used by The New York Times.


### PR DESCRIPTION
## Project URL
https://github.com/erenkabakci/WWDC17-Recap

## Description
Adding WWDC17-Recap
 
## Why it should be included to `awesome-ios`
I thought it would be useful to add WWDC-Recap repo since WWDC sessions are very valuable but they are only in video format. Markdown collections could be helpful for people looking for summaries. I am not sure about References section. Feel free to change.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
