### PR TITLE
Add xcproj to the Project Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2432,6 +2432,7 @@ Most of these are paid services, some have free tiers.
 * [amaro](https://github.com/crushlovely/Amaro) - iOS Boilerplate full of delights.
 * [chairs](https://github.com/orta/chairs) - Swap around your iOS Simulator Documents
 * [SwiftPlate](https://github.com/JohnSundell/SwiftPlate) - Easily generate cross platform Swift framework projects from the command line. :large_orange_diamond:
+* [xcproj](https://github.com/xcodeswift/xcproj) - Read and update Xcode projects.
 
 # Dependency / Package Manager
 * [CocoaPods](https://cocoapods.org/) - CocoaPods is the dependency manager for Objective-C projects. It has thousands of libraries and can help you scale your projects elegantly.


### PR DESCRIPTION
## Project URL
https://github.com/xcodeswift/xcproj

## Description
Add xcproj to the project setup section.
 
## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
