### PR TITLE
Add Bluebird.swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [BrightFutures](https://github.com/Thomvis/BrightFutures) - Write great asynchronous code in Swift using futures and promises. :large_orange_diamond:
 * [NoticeObserveKit](https://github.com/marty-suzuki/NoticeObserveKit) - NoticeObserveKit is type-safe NotificationCenter wrapper that associates notice type with info type. :large_orange_diamond:
 * [Hydra](https://github.com/malcommac/Hydra) - Promises & Await - Write better async code in Swift :large_orange_diamond:
+* [Bluebird.swift](https://github.com/AndrewBarba/Bluebird.swift) - Promise/A+, Bluebird inspired, implementation in Swift 4. :large_orange_diamond:
 
 ## Files
 * [FileKit](https://github.com/nvzqz/FileKit) - Simple and expressive file management in Swift. :large_orange_diamond:


### PR DESCRIPTION
## Project URL
https://github.com/AndrewBarba/Bluebird.swift

## Description
Adds a link to Bluebird.swift, a Promise library for Swift 4, to the EventBus section
 
## Why it should be included to `awesome-ios` (optional)
Bluebird is arguably the most popular Promise library in the Javascript/Node community. As developers are starting to move from one language to another, with Swift being a nice language to learn coming from Javascript, it's important to have familiarity. Bluebird.swift has around 80% of the functionality that Bluebird.js has, and makes a strong attempt to match naming and usage conventions while also providing a very Swift friendly API.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English