### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2791,12 +2791,12 @@ Most of these are paid services, some have free tiers.
 
 
 #### Facebook Groups
-* [HH iOS](https://www.facebook.com/groups/hhios/)
-* [Sketch - Official group](https://www.facebook.com/groups/sketchformac/)
-* [Design-Code](https://www.facebook.com/groups/designcode/)
-* [Sketch-Design.io](https://www.facebook.com/groups/sketchdesignio)
-* [Origami Community](https://www.facebook.com/groups/origami.community/)
-* [Framer JS](https://www.facebook.com/groups/framerjs/)
+* [HH iOS](https://www.facebook.com/groups/hhios/about/)
+* [Sketch - Official group](https://www.facebook.com/groups/sketchformac/about/)
+* [Design-Code](https://www.facebook.com/groups/designcode/about/)
+* [Sketch-Design.io](https://www.facebook.com/groups/sketchdesignio/about/)
+* [Origami Community](https://www.facebook.com/groups/origami.community/about/)
+* [Framer JS](https://www.facebook.com/groups/framerjs/about/)
 
 # Podcasts
 * [The Ray Wenderlich Podcast](https://www.raywenderlich.com/rwpodcast)

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Cupcake](https://github.com/nerdycat/Cupcake) - An easy way to create and layout UI components for iOS. :large_orange_diamond:
 * [MiniLayout](https://github.com/yonat/MiniLayout) - Minimal AutoLayout convenience layer. Program constraints succinctly. :large_orange_diamond:
 * [Bamboo](https://github.com/wordlessj/Bamboo) - Bamboo makes Auto Layout (and manual layout) elegant and concise. :large_orange_diamond:
-* [FlexLayout](https://github.com/lucdion/FlexLayout) - FlexLayout gently wraps the highly optimized [facebook/yoga](https://github.com/facebook/yoga) flexbox implementation in a concise, intuitive & chainable syntax. 🔶
+* [FlexLayout](https://github.com/layoutBox/FlexLayout) - FlexLayout gently wraps the highly optimized [facebook/yoga](https://github.com/facebook/yoga) flexbox implementation in a concise, intuitive & chainable syntax. 🔶
 * [Layout](https://github.com/schibsted/layout) - A declarative UI framework for iOS :large_orange_diamond:
 * [CGLayout](https://github.com/k-o-d-e-n/CGLayout) - Powerful autolayout framework based on constraints, that can manage UIView(NSView), CALayer and not rendered views. Not Apple Autolayout wrapper. 🔶
 * [YogaKit](https://github.com/facebook/yoga/tree/master/YogaKit) - Powerful layout engine which implements Flexbox. Developed and maintained by Facebook.
@@ -2775,7 +2775,7 @@ Most of these are paid services, some have free tiers.
 * [Swift Weekly Brief](https://swiftweekly.github.io/) - A community-driven weekly newsletter about Swift.org. Curated by Jesse Squires and published for free every Thursday
 * [Server-Side Swift Weekly](https://www.serverswift.tech) - A weekly newsletter with the best links related to server-side Swift and cross-platform developer tools. Curated by [@maxdesiatov](https://twitter.com/maxdesiatov)
 * [WeeklyCocoa.News](https://weeklycocoa.news) - Weekly updated newsletter about iOS, Swift, Objective-C, CocoaTouch, and other Apple connected development technologies.
-* [iOS Cookies Newsletter](http://us11.campaign-archive1.com/home/?u=cd1f3ed33c6527331d82107ba&id=532dc7fb64) - A weekly digest of new iOS libraries written in Swift.
+* [iOS Cookies Newsletter](https://us11.campaign-archive.com/home/?u=cd1f3ed33c6527331d82107ba&id=532dc7fb64) - A weekly digest of new iOS libraries written in Swift.
 
 #### Medium
 * [iOS App Development](https://medium.com/ios-os-x-development) - Stories and technical tips about building apps for iOS, Apple Watch, and iPad/iPhone


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
https://www.facebook.com/groups/designcode/ | https://www.facebook.com/groups/designcode/about/ 
https://www.facebook.com/groups/framerjs/ | https://www.facebook.com/groups/framerjs/about/ 
https://www.facebook.com/groups/hhios/ | https://www.facebook.com/groups/hhios/about/ 
https://www.facebook.com/groups/origami.community/ | https://www.facebook.com/groups/origami.community/about/ 
https://www.facebook.com/groups/sketchdesignio | https://www.facebook.com/groups/sketchdesignio/about/ 
https://www.facebook.com/groups/sketchformac/ | https://www.facebook.com/groups/sketchformac/about/ 
