### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2791,12 +2791,12 @@ Most of these are paid services, some have free tiers.
 
 
 #### Facebook Groups
-* [HH iOS](https://www.facebook.com/groups/hhios/)
-* [Sketch - Official group](https://www.facebook.com/groups/sketchformac/)
-* [Design-Code](https://www.facebook.com/groups/designcode/)
-* [Sketch-Design.io](https://www.facebook.com/groups/sketchdesignio)
-* [Origami Community](https://www.facebook.com/groups/origami.community/)
-* [Framer JS](https://www.facebook.com/groups/framerjs/)
+* [HH iOS](https://www.facebook.com/groups/hhios/about/)
+* [Sketch - Official group](https://www.facebook.com/groups/sketchformac/about/)
+* [Design-Code](https://www.facebook.com/groups/designcode/about/)
+* [Sketch-Design.io](https://www.facebook.com/groups/sketchdesignio/about/)
+* [Origami Community](https://www.facebook.com/groups/origami.community/about/)
+* [Framer JS](https://www.facebook.com/groups/framerjs/about/)
 
 # Podcasts
 * [The Ray Wenderlich Podcast](https://www.raywenderlich.com/rwpodcast)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
https://www.facebook.com/groups/designcode/ | https://www.facebook.com/groups/designcode/about/ 
https://www.facebook.com/groups/framerjs/ | https://www.facebook.com/groups/framerjs/about/ 
https://www.facebook.com/groups/hhios/ | https://www.facebook.com/groups/hhios/about/ 
https://www.facebook.com/groups/origami.community/ | https://www.facebook.com/groups/origami.community/about/ 
https://www.facebook.com/groups/sketchdesignio | https://www.facebook.com/groups/sketchdesignio/about/ 
https://www.facebook.com/groups/sketchformac/ | https://www.facebook.com/groups/sketchformac/about/ 
