### PR TITLE
[ci] white list facebook.com/groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - gem install danger
 script:
   - allowed_dupes=CONTRIBUTING,mocaplatform,Awesome-Swift-Education,XCDYouTubeKit,SRGMediaPlayer,PayPal-iOS-SDK,PerfectlySoft
-  - allowed_redirects=growthpush,awesomelinkcounter,eepurl,bluemix,amazon
+  - allowed_redirects=growthpush,awesomelinkcounter,eepurl,bluemix,amazon,facebook.com/groups
   - awesome_bot README.md --allow-ssl --white-list $allowed_dupes,$allowed_redirects
   - danger
 notifications:


### PR DESCRIPTION
Looks like facebook.com/groups now requires login = redirects.. will white list in ci to silence issues

cc: @lfarah @vsouza 