### PR TITLE
Consider Swift 4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
 - [ ] Only one project/change is in this pull request
 - [ ] Addition in chronological order (bottom of category)
 - [ ] Supports iOS 9 / tvOS 10 or later
-- [ ] Supports Swift 3 or later
+- [ ] Supports Swift 4 or later
 - [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English


### PR DESCRIPTION
Now that Swift 4 is mainstream, maybe we can consider using Swift 4 onward? Another suggestion, should we require a LICENSE to be included? It can be MIT, BSD, ... but it must at least state a license