### PR TITLE
Add L10n-swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
 * [IBLocalizable](https://github.com/PiXeL16/IBLocalizable) - Localize your views directly in Interface Builder with IBLocalizable :large_orange_diamond:
 * [nslocalizer](https://github.com/samdmarshall/nslocalizer) - A tool for finding missing and unused NSLocalizedStrings
+* [L10n-swift](https://github.com/Decybel07/L10n-swift) - Localization of an application with ability to change language "on the fly" and support for plural forms in any language. :large_orange_diamond:
 
 ## Logging
 * [CleanroomLogger](https://github.com/emaloney/CleanroomLogger) - A configurable and extensible Swift-based logging API that is simple, lightweight and performant. :large_orange_diamond:


### PR DESCRIPTION
Add L10n-swift

## Project URL
https://github.com/Decybel07/L10n-swift

## Category
Localization

## Description
Localization of an application with ability to change language "on the fly" and support for plural forms in any language.
 
## Why it should be included to `awesome-ios` (optional)
- Change the language of your apps "on the fly".
- IBInspectable for Xcode Interface Builder.
- Support for: iOS 9.0+ | macOS 10.10+ | tvOS 9.0+ | watchOS 2.0+
- Support for user-defined `Localizable` file names.
- Support for formats: `*.plist`, `*.json`, `*.stringsdict`, `*.strings`.
- Support for grouping localization keys.
- Support for **plural** forms in any language.
- Use `.l10n()` to localized any string, date, int, and double.
- Use more than one languages at the same time.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English