### PR TITLE
Add XcodeGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2594,6 +2594,7 @@ Most of these are paid services, some have free tiers.
 * [LifetimeTracker](https://github.com/krzysztofzablocki/LifetimeTracker) - Find retain cycles / memory leaks sooner. :large_orange_diamond:
 * [Plank](https://github.com/pinterest/plank) - A tool for generating immutable model objects.
 * [Lona](https://github.com/airbnb/Lona) - A tool for defining design systems and using them to generate cross-platform UI code, Sketch files, images, and other artifacts.
+* [XcodeGen](https://github.com/yonaskolb/XcodeGen) - Command line tool that generates your Xcode project from a spec file and your folder structure. :large_orange_diamond:
 
 # Rapid Development
 * [Playgrounds](https://github.com/krzysztofzablocki/Playgrounds) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
Adds XcodeGen

## Project URL
https://github.com/yonaskolb/XcodeGen

## Category
Tools. (Though it could go in `Xcode.Other` or `Project Setup`. Should it be added to all, or just one?

## Description
XcodeGen is a command line tool that generates your Xcode project using your folder structure and a simple project spec.

The project spec is a YAML or JSON file that defines your targets, configurations, schemes and custom build settings. All you source directories are automatically parsed and referenced appropriately while preserving your folder structure. Sensible defaults are used in many places, so you only need to customize what is needed.
 
## Why it should be included to `awesome-ios` (optional)
- ✅ Easy **configuration** of projects which is human readable and git friendly
- ✅ Groups in Xcode are always **synced** to your directories on disk
- ✅ Create projects on demand and remove your `.xcodeproj` file from git, which means **no merge conflicts**!
- ✅ Easily **copy and paste** files and directories without having to edit anything in xcode
- ✅ Share build settings across multiple targets with **build setting groups**
- ✅ Automatically generate Schemes for **different environments** like test and production
- ✅ Easily **create new projects** with complicated setups on demand without messing around with Xcode
- ✅ Generate from anywhere including **Continuous Delivery** servers
- ✅ Distribute your spec amongst multiple files for easy **sharing** and overriding

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
