### PR TITLE
Add iSimulator:GUI utility to control the Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2597,6 +2597,7 @@ Most of these are paid services, some have free tiers.
 * [Plank](https://github.com/pinterest/plank) - A tool for generating immutable model objects.
 * [Lona](https://github.com/airbnb/Lona) - A tool for defining design systems and using them to generate cross-platform UI code, Sketch files, images, and other artifacts.
 * [XcodeGen](https://github.com/yonaskolb/XcodeGen) - Command line tool that generates your Xcode project from a spec file and your folder structure. :large_orange_diamond:
+* [iSimulator](https://github.com/wigl/iSimulator) - iSimulator is a GUI utility to control the Simulator, and manage the app installed on the simulator.
 
 # Rapid Development
 * [Playgrounds](https://github.com/krzysztofzablocki/Playgrounds) - Playgrounds for Objective-C for extremely fast prototyping / learning.


### PR DESCRIPTION
## Project URL
https://github.com/wigl/iSimulator

## Category
Tools

## Description
iSimulator is a GUI utility to control the Simulator, and manage the app installed on the simulator. 
* Start, shutdown a simulator, and can start multiple simulators at the same time.
* Easy to access application bundle, sandbox folder. iSimulator will create a folder that contains the app's bundle and sandbox. This will make access app's data easier.
* Launch one application for other simulator. Very easy to share an app to other simulators without having to rebuild.
 
## Why it should be included to `awesome-ios` 
It improves development efficiency.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
