### PR TITLE
Add StatusAlert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1926,6 +1926,7 @@ Most of these are paid services, some have free tiers.
 * [BulletinBoard](https://github.com/alexaubry/BulletinBoard) - Generate and Display Bottom Card Interfaces on iOS :large_orange_diamond:
 * [Cards](https://github.com/PaoloCuscela/Cards) - Awesome iOS 11 AppStore's Card Views. :large_orange_diamond:
 * [CFNotify](https://github.com/hallelujahbaby/CFNotify) - A customizable framework to create draggable views. :large_orange_diamond:
+* [StatusAlert](https://github.com/LowKostKustomz/StatusAlert) - Display Apple system-like self-hiding status alerts without interrupting user flow. :large_orange_diamond:
 
 #### Badge
 * [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons. :large_orange_diamond:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
StatusAlert will be displayed on the screen without interrupting user flow. It can have the same look and feel as the system private alert (e.g., used in Apple Music app) and at the same time is very customizable.

## Project URL
https://github.com/LowKostKustomz/StatusAlert

## Category
Alert & Action Sheet

## Description
Display Apple system-like self-hiding status alerts without interrupting user flow.
 
## Why it should be included to `awesome-ios` (optional)
It is the best way to display success/failure message following the Apple Design Guidelines.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English