### PR TITLE
Add AppFolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [ZipArchive](https://github.com/ZipArchive/ZipArchive) - ZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.
 * [FileExplorer](https://github.com/Augustyniak/FileExplorer) - Powerful file browser for iOS that allows its users to choose and remove files and/or directories. :large_orange_diamond:
 * [ZIPFoundation](https://github.com/weichsel/ZIPFoundation) - Effortless ZIP Handling in Swift :large_orange_diamond:
+* [AppFolder](https://github.com/dreymonde/AppFolder) - AppFolder is a lightweight framework that lets you design a friendly, strongly-typed representation of a directories inside your app's container. :large_orange_diamond:
 
 ## Functional Programming
 * [Forbind](https://github.com/ulrikdamm/Forbind) - Functional chaining and promises in Swift. :large_orange_diamond:


### PR DESCRIPTION
🗂 Never use NSSearchPathForDirectoriesInDomains again. Never.

## Project URL
https://github.com/dreymonde/AppFolder

## Category
[Files](https://github.com/vsouza/awesome-ios#files)

## Description
AppFolder is a lightweight framework that lets you design a friendly, strongly-typed representation of a directories inside your app's container. All the system directories like "Caches/" and "Application Support/" are already present, and you can add yours using just a few lines of code.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English