### PR TITLE
Add OCMock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,6 +1587,7 @@ Most of these are paid services, some have free tiers.
 * [MirrorDiffKit](https://github.com/Kuniwak/MirrorDiffKit) - Pretty diff between any structs or classes :large_orange_diamond:
 * [SnappyTestCase](https://github.com/tooploox/SnappyTestCase) - iOS Simulator type agnostic snapshot testing, built on top of the FBSnapshotTestCase. :large_orange_diamond:
 * [XCTestExtensions](https://github.com/shindyu/XCTestExtensions) - XCTestExtensions is a Swift extension that provides convenient assertions for writing Unit Test. 🔶
+* [OCMock](http://ocmock.org) - Mock objects for Objective-C.  
 
 ## UI
 * [FlatUIKit](https://github.com/Grouper/FlatUIKit) - A collection of awesome flat UI components for iOS.


### PR DESCRIPTION
Add OCMock library in "Other Testing" section.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
http://ocmock.org/

## Category
[Other Testing](https://github.com/vsouza/awesome-ios#other-testing)

## Description
OCMock - is a library for creation mock, stub object in test.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
