### PR TITLE
Add swift-corelibs-xctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,7 @@ Most of these are paid services, some have free tiers.
 * [Sleipnir](https://github.com/railsware/Sleipnir) - BDD-style framework for Swift :large_orange_diamond:
 * [SwiftCheck](https://github.com/typelift/SwiftCheck) - QuickCheck for Swift :large_orange_diamond:
 * [Spry](https://github.com/Quick/Spry) - A Mac and iOS Playgrounds Unit Testing library based on Nimble. 🔶
+* [swift-corelibs-xctest](https://github.com/apple/swift-corelibs-xctest) - The XCTest Project, A Swift core library for providing unit test support. :large_orange_diamond:
 
 #### A/B Testing
 * [Switchboard](https://github.com/KeepSafe/Switchboard) - Switchboard - easy and super light weight A/B testing for your mobile iPhone or android app. This mobile A/B testing framework allows you with minimal servers to run large amounts of mobile users.


### PR DESCRIPTION
The XCTest Project, A Swift core library for providing unit test support.

## Project URL
https://github.com/apple/swift-corelibs-xctest

## Category
[Testing](https://github.com/vsouza/awesome-ios#testing)

## Description
The XCTest library is designed to provide a common framework for writing unit tests in Swift, for Swift packages and applications.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English