### PR TITLE
Add PMHTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,6 +1195,7 @@ Most of these are paid services, some have free tiers.
 * [WAMapping](https://github.com/Wasappli/WAMapping) - A library to turn dictionary into object and vice versa for iOS. Designed for speed!
 * [json-swift](https://github.com/owensd/json-swift) - A basic library for working with JSON in Swift. 
 * [Himotoki](https://github.com/ikesyo/Himotoki) - A type-safe JSON decoding library purely written in Swift. 
+* [PMHTTP](https://github.com/postmates/PMHTTP) - Swift/Obj-C HTTP framework with a focus on REST and JSON. 
 
 #### XML & HTML
 * [AEXML](https://github.com/tadija/AEXML) - Simple and lightweight XML parser written in Swift. 


### PR DESCRIPTION
Swift/Obj-C HTTP framework with a focus on REST and JSON

## Project URL
https://github.com/postmates/PMHTTP

## Category
[Parsing/JSON](https://github.com/vsouza/awesome-ios#json)

## Description
PMHTTP is an HTTP framework built around URLSession and designed for Swift while retaining Obj-C compatibility.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English