### PR TITLE
Added AssetImportKit - Swifty cross platform library (macOS, iOS) that converts Assimp supported models to SceneKit scenes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [ShogibanKit](https://github.com/codelynx/ShogibanKit) - ShogibanKit is a framework for implementing complex Japanese Chess (Shogii) in Swift. No UI, nor AI. 
 * [SKTiled](https://github.com/mfessenden/SKTiled) - Swift framework for working with Tiled assets in SpriteKit 
 * [CollectionNode](https://github.com/bwide/CollectionNode) - A swift framework for a collectionView in SpriteKit 
+* [AssetImportKit](https://github.com/eugenebokhan/Asset-Import-Kit) - Swifty cross platform library (macOS, iOS) that converts Assimp supported models to SceneKit scenes.
 
 ## GCD
  * [GCDKit](https://github.com/JohnEstropia/GCDKit) - Grand Central Dispatch simplified with Swift. 


### PR DESCRIPTION
Added Swifty cross platform library (macOS, iOS) that converts Assimp supported models to SceneKit scenes.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->

## Category
<!--- Category in AwesomeiOS where the project will be added -->

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
