### PR TITLE
Add Rome to dependecy/packet manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2634,6 +2634,7 @@ Most of these are paid services, some have free tiers.
 * [CocoaSeeds](https://github.com/devxoul/CocoaSeeds) - Git Submodule Alternative for Cocoa.
 * [swift-package-manager](https://github.com/apple/swift-package-manager) - The Package Manager for the Swift Programming Language 
 * [punic](https://github.com/schwa/punic) - Clean room reimplementation of Carthage tool
+* [Rome](https://github.com/blender/Rome) - A cache tool for Carthage built frameworks
 
 # Tools
 * [Shark](https://github.com/kaandedeoglu/Shark) - Swift Script that transforms the .xcassets folder into a type safe enum. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/blender/Rome

## Category
Dependency / Package Manager

## Description
Add Rome to the list. Rome is cache manager for projects using Carthage.
 
## Why it should be included to `awesome-ios` (optional)
- It's a decent tool to speed up build times by caching build artifacts locally, remotely or both.
- Supports CI workflow
- Supports team setup


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
