### PR TITLE
Removed MVMaterialView

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,7 +1654,6 @@ Most of these are paid services, some have free tiers.
 * [Motif](https://github.com/erichoracek/Motif) - A lightweight and customizable JSON stylesheet framework for iOS.
 * [Texture](https://github.com/TextureGroup/Texture) - Smooth asynchronous user interfaces for iOS apps.
 * [GaugeKit](https://github.com/skywinder/GaugeKit) - Customizable gauges. Easy reproduce Apple's style gauges. 
-* [MVMaterialView](https://github.com/TheMrugraj/MVMaterialView) - Subclass of UIControls and UIButton to mimic Ripple effect of Material Design concept.
 * [TisprCardStack](https://github.com/tispr/tispr-card-stack) - Library that allows to have cards UI. 
 * [SAHistoryNavigationViewController](https://github.com/marty-suzuki/SAHistoryNavigationViewController) - SAHistoryNavigationViewController realizes iOS task manager like UI in UINavigationContoller,3D Touch Compatible. 
 * [SAInboxViewController](https://github.com/marty-suzuki/SAInboxViewController) - UIViewController subclass inspired by "Inbox by google" animated transitioning. 


### PR DESCRIPTION
README lacks information. I already opened [an issue](https://github.com/TheMrugraj/MVMaterialView/issues/6) and the README still lacks information

## Project URL
<!--- The project URL -->
https://github.com/TheMrugraj/MVMaterialView

## Category
<!--- Category in AwesomeiOS where the project will be added -->
UI