### PR TITLE
Moved greedo-layout-for-ios to /Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Avatar](https://github.com/wvabrinskas/Avatar) - Generate random user Avatar images using CoreGraphics and QuartzCore. 
 * [Serrata](https://github.com/horitaku46/Serrata) - Slide image viewer library similar to Twitter and LINE.
 * [StyleArt](https://github.com/ileafsolutions/StyleArt) - Style Art library process images using COREML with a set of pre trained machine learning models and convert them to Art style. 
+* [greedo-layout-for-ios](https://github.com/500px/greedo-layout-for-ios) - Full aspect ratio grid layout for iOS
 
 #### Media Processing
 * [SwiftOCR](https://github.com/garnele007/SwiftOCR) - Fast and simple OCR library written in Swift 
@@ -1697,7 +1698,6 @@ Most of these are paid services, some have free tiers.
 * [Spots](https://github.com/hyperoslo/Spots) - Spots is a view controller framework that makes your setup and future development blazingly fast. 
 * [APAddressBook](https://github.com/Alterplay/APAddressBook) - Easy access to iOS address book
 * [AZExpandableIconListView](https://github.com/Azuritul/AZExpandableIconListView) - An expandable/collapsible view component written in Swift. 
-* [greedo-layout-for-ios](https://github.com/500px/greedo-layout-for-ios) - Full aspect ratio grid layout for iOS
 * [FlourishUI](https://github.com/thinkclay/FlourishUI) - A highly configurable and out-of-the-box-pretty UI library 
 * [GranadaLayout](https://github.com/gskbyte/GranadaLayout) - Alternative layout system for iOS, inspired on the Android layout system, that includes linear and relative layouts, as well as an extensible JSON-based layout inflater.
 * [Navigation Stack](https://github.com/Ramotion/navigation-stack) - Navigation Stack is a stack-modeled navigation controller. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I also thought we could put under [/TableView & CollectionView](https://github.com/vsouza/awesome-ios#table-view--collection-view)

## Project URL
<!--- The project URL -->
https://github.com/500px/greedo-layout-for-ios

## Category
<!--- Category in AwesomeiOS where the project will be added -->
 /Image

## Description
<!--- Describe your changes in detail -->
 Full aspect ratio grid layout for iOS
