### PR TITLE
Add XVim2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2779,6 +2779,7 @@ Most of these are paid services, some have free tiers.
 # Xcode
 
 #### Extensions (Xcode 8+)
+* [XVim2](https://github.com/XVimProject/XVim2) - Vim key-bindings for Xcode 9. 
 * [CleanClosureXcode](https://github.com/BalestraPatrick/CleanClosureXcode) - An Xcode Source Editor extension to clean the closure syntax. 
 * [xTextHandler](https://github.com/cyanzhong/xTextHandler) - Xcode Source Editor Extension Toolset (Plugins for Xcode 8) 
 * [SwiftInitializerGenerator](https://github.com/Bouke/SwiftInitializerGenerator) - Xcode 8 Source Code Extension to Generate Swift Initializers. 

--- a/README.md
+++ b/README.md
@@ -2779,7 +2779,6 @@ Most of these are paid services, some have free tiers.
 # Xcode
 
 #### Extensions (Xcode 8+)
-* [XVim2](https://github.com/XVimProject/XVim2) - Vim key-bindings for Xcode 9. 
 * [CleanClosureXcode](https://github.com/BalestraPatrick/CleanClosureXcode) - An Xcode Source Editor extension to clean the closure syntax. 
 * [xTextHandler](https://github.com/cyanzhong/xTextHandler) - Xcode Source Editor Extension Toolset (Plugins for Xcode 8) 
 * [SwiftInitializerGenerator](https://github.com/Bouke/SwiftInitializerGenerator) - Xcode 8 Source Code Extension to Generate Swift Initializers. 
@@ -2791,6 +2790,7 @@ Most of these are paid services, some have free tiers.
 * [Swiftify](https://objectivec2swift.com/) - Objective-C to Swift online code converter and Xcode extension. 
 * [DocumenterXcode](https://github.com/serhii-londar/DocumenterXcode) - Attempt to give a new life for VVDocumenter-Xcode as source editor extension. 
 * [Snowonder](https://github.com/Karetski/Snowonder) - 🔮 Magical import declarations formatter for Xcode.
+* [XVim2](https://github.com/XVimProject/XVim2) - Vim key-bindings for Xcode 9. 
 
 #### Themes
 * [Dracula Theme](https://draculatheme.com/xcode/) - A dark theme for Xcode.


### PR DESCRIPTION
Add XVim2: Vim key-bindings for Xcode 9

## Project URL
https://github.com/XVimProject/XVim2

## Category
Extensions (Xcode 8+)

## Description
Vim key-bindings for Xcode 9
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
