### PR TITLE
Add MapViewPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [JDSwiftHeatMap](https://github.com/jamesdouble/JDSwiftHeatMap) - JDSwiftMap is an IOS Native MapKit Library. You can easily make a highly customized HeatMap. 
 * [ClusterKit](https://github.com/hulab/ClusterKit) - An iOS map clustering framework targeting MapKit, Google Maps and Mapbox.
 * [FlyoverKit](https://github.com/SvenTiigi/FlyoverKit) - FlyoverKit enables you to present stunning 360° flyover views on your MKMapView with zero effort while maintaining full configuration possibilities.
+* [MapViewPlus](https://github.com/okhanokbay/MapViewPlus) - Use any custom view as custom callout view of your MKMapView with cool animations. Also, easily use any image as annotation view.
 
 ## Math
 * [Euler](https://github.com/mattt/Euler) - Swift Custom Operators for Mathematical Notation 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/okhanokbay/MapViewPlus

## Category
Maps

## Description
MapViewPlus gives you the missing methods of MKMapView which are: `imageForAnnotation` and `calloutViewForAnnotationView` delegate methods. 
 
## Why it should be included to `awesome-ios` 
Implementing custom callout views and image annotation views seems easy at first but when you dive deep into it, you see how tricky it can become. MapViewPlus covers all of these trickiness and just asks you for the UIView instance for callout view and UIImage instance for annotation view. It handles the rest and deals with the limitations of MKMapView itself. Also, allows you to use cool spring animations.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English