### PR TITLE
Add KeyPathKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Differ](https://github.com/tonyarnold/Differ) - Swift library to generate differences and patches between collections.
 * [Probably](https://github.com/harlanhaskins/Probably) - A Swift probability and statistics library. 
 * [RandMyMod](https://github.com/jamesdouble/RandMyMod) - RandMyMod base on your own struct or class create one or a set of randomized instance.
+* [KeyPathKit](https://github.com/vincent-pradeilles/KeyPathKit) - KeyPathKit provides a seamless syntax to manipulate data using typed keypaths.
 
 ## Date & Time
 


### PR DESCRIPTION
## Project URL
[https://github.com/vincent-pradeilles/KeyPathKit]()

## Category
Data Structures / Algorithms

## Description
KeyPathKit is a library that provides the standard functions to manipulate data along with a call-syntax that relies on typed keypaths to male the call sites as short and clean as possible.
 
## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English