### PR TITLE
Add Virgil Security Swift SDK to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,6 +1497,7 @@ Most of these are paid services, some have free tiers.
 * [KKPinCodeTextField](https://github.com/kolesa-team/ios_pinCodeTextField) - A customizable verification code textField for phone verification codes, passwords etc.
 * [🗄 Vault](https://github.com/umbri/Vault) - Simple and Secure container for passwords and other sensitive data
 * [Virgil SWIFT PFS SDK](https://github.com/VirgilSecurity/virgil-sdk-pfs-x) - An SDK that allows developers to add the Perfect Forward Secrecy (PFS) technologies to their digital solutions to protect previously intercepted traffic from being decrypted even if the main Private Key is compromised.
+* [Virgil Security Objective-C/Swift SDK](https://github.com/VirgilSecurity/virgil-sdk-x) - An SDK which allows developers to add full end-to-end security to their existing digital solutions to become HIPAA and GDPR compliant and more using Virgil API. 
 
 #### Encryption
 * [AESCrypt-ObjC](https://github.com/Gurpartap/AESCrypt-ObjC) - A simple and opinionated AES encrypt / decrypt Objective-C class that just works.


### PR DESCRIPTION
Virgil Security Objective-C/Swift SDK

## Project URL
https://github.com/VirgilSecurity/virgil-sdk-x

## Category
Security

## Description
An SDK which allows developers to add full end-to-end security to their existing digital solutions to become HIPAA and GDPR compliant and more using Virgil API. 

## Why it should be included to `awesome-ios` (optional)
This SDK is not a duplicate: it uses technologies different from PFS SDK and is created for other purposes, such as encrypting stored data for example. 

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
