### PR TITLE
Added Placenote

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [ARVideoKit](https://github.com/AFathi/ARVideoKit) - Record and capture ARKit videos 📹, photos 🌄, Live Photos 🎇, and GIFs 🎆. 
 * [ARKitEnvironmentMapper](https://github.com/svtek/ARKitEnvironmentMapper) - A library that allows you to generate and update environment maps in real-time using the camera feed and ARKit's tracking capabilities. 
 * [SmileToUnlock](https://github.com/rsrbk/SmileToUnlock) - This library uses ARKit Face Tracking in order to catch a user's smile.
+* [Placenote](https://github.com/Placenote/PlacenoteSDK-iOS) - A library that makes ARKit sessions persistent to a location using advanced computer vision
 
 ## Authentication
 * [Heimdallr.swift](https://github.com/trivago/Heimdallr.swift) - Easy to use OAuth 2 library for iOS, written in Swift. 


### PR DESCRIPTION
## Project URL
https://github.com/Placenote/PlacenoteSDK-iOS

## Category
ARKit

## Description
The Placenote library adds persistence to your ARKit Sessions. For example, if you create an ARKit furniture preview app, the scene recognition software within Placenote will remember where your user placed your furniture in their house. The library is built in the cloud by default, so ARKit sessions can be shared between users and phones. Use it for ARKit multiplayer game sessions, guided tours, interior decoration or general spatial computing!
 
## Why it should be included to `awesome-ios` (optional)
Its the one missing piece when trying to make meaningful ARKit experiences and tools. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
