### PR TITLE
Added LearnAppMaking.com to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -2991,6 +2991,7 @@ CollectionView, make Instagram Discover within minutes.
 * [The Swift Summary Book](https://github.com/jakarmy/swift-summary) - A summary of Apple's Swift language written on Playgrounds.
 * [Hacking With Swift](https://www.hackingwithswift.com) - Learn to code iPhone and iPad apps with 3 Swift tutorials.
 * [Realm Academy](https://academy.realm.io/)
+* [LearnAppMaking](https://learnappmaking.com) - LearnAppMaking helps app developers to build, launch and market iOS apps.
 
 ### iOS UI Template
 * [iOS UI Design Kit](https://www.invisionapp.com/tethr)


### PR DESCRIPTION
## Project URL
[https://learnappmaking.com](https://learnappmaking.com)

## Category
Tutorials

## Description
Added LearnAppMaking to the Tutorial section. It should be added because it's awesome \*\*cough\*\* shameless plug \*\*cough\*\*  – no really, I'm passionate about sitting down with devs to help them play with code, and I think that shines through the website :-)
 
## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [ ] ~~Has a commit from less than 2 years ago~~
- [ ] ~~Has a **clear** README in English~~
