### PR TITLE
Add NominatimKit to Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [LocationPicker](https://github.com/JeromeTan1997/LocationPicker) - A ready for use and fully customizable location picker for your app
 * [BBLocationManager](https://github.com/benzamin/BBLocationManager) - A Location Manager for easily implementing location services & geofencing in iOS.
 * [set-simulator-location](https://github.com/lyft/set-simulator-location) - CLI for setting location in the iOS simulator.
+* [NominatimKit](https://github.com/caloon/NominatimKit) - A Swift wrapper for (reverse) geocoding of OpenStreetMap data.
 
 ### Other Hardware
 


### PR DESCRIPTION
## Project URL
https://github.com/caloon/NominatimKit

## Category
Location

## Description
NominatimKit lets you (reverse) geocode OpenStreetMap data. It can be used to map addresses and landmarks to geo coordinates (and vice versa).
 
## Why it should be included to `awesome-ios` (optional)
Free to use and very interesting for anyone who works with addresses and geo data.

## Checklist
- [ x ] Only one project/change is in this pull request
- [ x ] Addition in chronological order (bottom of category)
- [ x ] Supports iOS 9 / tvOS 10 or later
- [ x ] Supports Swift 4 or later
- [ x ] Has a commit from less than 2 years ago
- [ x ] Has a **clear** README in English
