### PR TITLE
add DZURLRoute .  Universal route engine for iOS app, it can handle URLScheme between applications and page route between UIViewController.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [RxFlow](https://github.com/RxSwiftCommunity/RxFlow) - Navigation framework for iOS applications based on a Reactive Flow Coordinator pattern.
 * [Linker](https://github.com/MaksimKurpa/Linker) - Lightweight way to handle internal and external deeplinks for iOS.
 * [CoreNavigation](https://github.com/aronbalog/CoreNavigation) - 📱📲 Navigate between view controllers with ease.
+* [DZURLRoute](https://github.com/yishuiliunian/DZURLRoute) - Universal route engine for iOS app, it can handle URLScheme between applications and page route between UIViewController.
+
 
 ## Apple TV
 * [Voucher](https://github.com/rsattar/Voucher) - A simple library to make authenticating tvOS apps easy via their iOS counterparts.


### PR DESCRIPTION
add DZURLRoute .  Universal route engine for iOS app, it can handle URLScheme between applications and page route between UIViewController.

## Project URL

https://github.com/yishuiliunian/DZURLRoute

## Category

App Routing


## Description

Universal route engine for iOS app, it can handle URLScheme between applications and page route between UIViewController.
 
## Why it should be included to `awesome-ios` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Only one project/change is in this pull request
- [ x ] Addition in chronological order (bottom of category)
- [ x ] Supports iOS 9 / tvOS 10 or later
- [x  ] Supports Swift 4 or later
- [x  ] Has a commit from less than 2 years ago
- [ x ] Has a **clear** README in English
