### PR TITLE
Add Athena

### DIFF
--- a/README.md
+++ b/README.md
@@ -2836,7 +2836,7 @@ CollectionView, make Instagram Discover within minutes.
 * [swift-package-manager](https://github.com/apple/swift-package-manager) - The Package Manager for the Swift Programming Language
 * [punic](https://github.com/schwa/punic) - Clean room reimplementation of Carthage tool
 * [Rome](https://github.com/blender/Rome) - A cache tool for Carthage built frameworks
-
+* [Athena](https://github.com/yunarta/works-athena-gradle-plugin) - Gradle Plugin to enhance Carthage by uploading the archived frameworks into Maven repository, currently support only Bintray, Artifactory and Mavel local.
 
 ## Tools
 


### PR DESCRIPTION
## Project URL
https://github.com/yunarta/works-athena-gradle-plugin

## Category
Dependency / Package Manager

## Description
Athena is a Gradle plugin that would make usage of Carthage even more powerful
- The Carthage archives will be hosted in Maven repository (currently only supports Bintray and Artifactory)
- Even though its Gradle plugin (may sounds like why we use Android thingie for iOS), the usage is basically your typical write tools execution file, and executes with gradle.

## Why it should be included to `awesome-ios` (optional)
- As Carl Sagan said "When you're in love, you want to tell the world."
- Hopefully the community will picks up the tools, and we can have a Maven style repository for Carthage (no more individual S3 bucket)

As for the checklist requirement
Unit test can be found here - http://jenkins.mobilesolutionworks.com:8080/job/github/job/yunarta/job/works-athena-gradle-plugin/job/master/

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
