### PR TITLE
Add TvOSSlider

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [TvOSPinKeyboard](https://github.com/zattoo/TvOSPinKeyboard) - PIN keyboard for tvOS
 * [TvOSScribble](https://github.com/dcordero/TvOSScribble) - Handwriting numbers recognizer for Siri Remote
 * [TvOSCustomizableTableViewCell](https://github.com/zattoo/TvOSCustomizableTableViewCell) - Light wrapper of UITableViewCell that allows extra customization for tvOS
+* [TvOSSlider](https://github.com/zattoo/TvOSSlider) - TvOSSlider is an implementation of UISlider for tvOS
 
 ## Architecture Patterns
 


### PR DESCRIPTION
## Project URL
https://github.com/zattoo/TvOSSlider

## Category
Apple TV

## Description
TvOSSlider palliates missing an implementation of UISlider for tvOS as part of UIKit.

## Why it should be included to `awesome-ios` (optional)

## Checklist
- [x] Only one project/change is in this pull request
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English