### PR TITLE
Removed ImagePicker (due to deprecation). Closes #2648

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,6 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Cool-iOS-Camera](https://github.com/GabrielAlva/Cool-iOS-Camera) - A fully customisable and modern camera implementation for iOS made with AVFoundation.
 * [SCRecorder](https://github.com/rFlex/SCRecorder) - Camera engine with Vine-like tap to record, animatable filters, slow motion, segments editing.
 * [ALCameraViewController](https://github.com/AlexLittlejohn/ALCameraViewController) - A camera view controller with custom image picker and image cropping. Written in Swift.
-* [ImagePicker](https://github.com/hyperoslo/ImagePicker) - Reinventing the way ImagePicker works.
 * [CameraManager](https://github.com/imaginary-cloud/CameraManager) - Simple Swift class to provide all the configurations you need to create custom camera view in your app.
 * [RSBarcodes_Swift](https://github.com/yeahdongcn/RSBarcodes_Swift) - 1D and 2D barcodes reader and generators for iOS 8 with delightful controls. Now Swift.
 * [LLSimpleCamera](https://github.com/omergul/LLSimpleCamera) - A simple, customizable camera control - video recorder for iOS.


### PR DESCRIPTION
## Project URL
https://github.com/hyperoslo/ImagePicker

## Category
Camera

## Description
Removed a now deprecated project.

## Why it should be included to `awesome-ios` (mandatory)
Having an up to date list is very important. This is just a natural part of the curation process.

## Checklist
- [X] Only one project/change is in this pull request
- [ ] Has unit tests, integration tests or UI tests
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
