### PR TITLE
Add MRSelectCountry in List

### DIFF
--- a/README.md
+++ b/README.md
@@ -1999,6 +1999,7 @@ Most of these are paid services, some have free tiers.
 * [HGRippleRadarView](https://github.com/HamzaGhazouani/HGRippleRadarView) - A beautiful radar view to show nearby items (users, restaurants, ...) with ripple animation, fully customizable
 * [GDGauge](https://github.com/saeid/GDGauge) - Full Customizable, Beautiful, Easy to use gauge view Edit. 🔶
 * [STAControls](https://github.com/Stunner/STAControls) - Handy UIControl subclasses. (Think Three20/NimbusKit of UIControls.) Written in Objective-C.
+* [MRSelectCountry](https://github.com/mrazam110/MRSelectCountry) - Easy way to get country data which includes country name and dial code for iOS Developers.
 
 
 ### Activity Indicator


### PR DESCRIPTION
MRSelectCountry - Easy way to get country data which includes the country name and dial code for iOS Developers

## Project URL
https://github.com/mrazam110/MRSelectCountry

## Category
UI

## Description
I just added MRSelectCountry in list

## Why it should be included to `awesome-ios` (mandatory)
It's easy to use just plug and play type so devs can use it easily. Devs follow awesome-ios that's why I want my repo to be there.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
