### PR TITLE
Added Page-Control to UIPageControl section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2815,6 +2815,7 @@ CollectionView, make Instagram Discover within minutes.
 * [PageControl](https://github.com/kasper-lahti/PageControl) - ● ○ ○ ○ A nice, animated UIPageControl alternative.
 * [PageControls](https://github.com/popwarsweet/PageControls) - This is a selection of custom page controls to replace UIPageControl, inspired by a dribbble found here
 * [CHIPageControl](https://github.com/ChiliLabs/CHIPageControl) - A set of cool animated page controls to replace boring UIPageControl.
+* [Page-Control](https://github.com/vovaseuruk/page-control) - 💥 Beautiful, animated and highly customizable UIPageControl alternative.
 
 ### Web View
 * [Otafuku](https://github.com/tasanobu/Otafuku) - Otafuku provides utility classes to use WKWebView in Swift.


### PR DESCRIPTION
## Project URL
https://github.com/vovaseuruk/page-control

## Category
UIPageControl

## Description
Highly customizable UIPageControl alternative for iOS.

## Why it should be included to `awesome-ios` (mandatory)
UIPageControl is not very customizable (it only allows to change indicator colors, number of pages and current page), so developer usually needs to implement his own custom PageControl and update it with his needs.
[Page-Control](https://github.com/vovaseuruk/page-control) is highly customizable and I've made pretty much everything iOS developer would need from UIPageControl and I'd like to share it with others. 

## Checklist
- [x] Only one project/change is in this pull request
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
