### PR TITLE
Add MailController

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,6 +1339,7 @@ Also see [push notifications](#push-notifications)
 
 * [Mail Core 2](https://github.com/MailCore/mailcore2) - MailCore 2 provide a simple and asynchronous API to work with e-mail protocols IMAP, POP and SMTP.
 * [Postal](https://github.com/snipsco/Postal) - A swift framework providing simple access to common email providers.
+* [MailController](https://github.com/Kulich-ua/MailController) - Lightweight Swift wrapper around MFMailComposeViewController.
 
 ## Representations
 


### PR DESCRIPTION
## Project URL
https://github.com/Kulich-ua/MailController

## Category
Networking

## Description
Add MailController to the Email subcategory of the Networking category.

## Why it should be included to `awesome-ios` (mandatory)
MailController is a lightweight Swift wrapper around MFMailComposeViewController, which provides you with a convenient interface. It eliminates the use of delegation pattern and instead provides a block-based API if necessary. 

## Checklist
- [x] Only one project/change is in this pull request
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English