### PR TITLE
Update README.md to List out new library - OnlyPictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2007,6 +2007,7 @@ Most of these are paid services, some have free tiers.
 * [GDGauge](https://github.com/saeid/GDGauge) - Full Customizable, Beautiful, Easy to use gauge view Edit. 🔶
 * [STAControls](https://github.com/Stunner/STAControls) - Handy UIControl subclasses. (Think Three20/NimbusKit of UIControls.) Written in Objective-C.
 * [ApplyStyleKit](https://github.com/shindyu/ApplyStyleKit) - Elegant apply style, using Swift Method Chain.
+* [OnlyPictures](https://github.com/KiranJasvanee/OnlyPictures) - A simple and flexible way to add source of overlapping circular pictures, currently supports horizontal overlapping or distant pictures with great layout flexibility.
 
 
 ### Activity Indicator


### PR DESCRIPTION
Listed my overlapping circular pictures layout library.

Few months ago I've created one cool library of showing circular overlapping pictures which is popular now and eligible to take place in awesome-ios.

## Project URL
https://github.com/KiranJasvanee/OnlyPictures

## Category
UI

## Description
Listed this library in UI category

## Why it should be included to `awesome-ios` (mandatory)
This is the only kind of library with numerous flexibilities of lay-outing overlapping circular pictures. This is attractive and prevalent layout to show users now. It has to be in awesome-ios, so it can be reached to more ios developers.  

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
