### PR TITLE
Add CoreXLSX to Other Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,6 +1476,7 @@ Most of these are paid services, some have free tiers.
 * [SwiftCssParser](https://github.com/100mango/SwiftCssParser) - A Powerful , Extensible CSS Parser written in pure Swift.
 * [RLPSwift](https://github.com/bitfwdcommunity/RLPSwift) - Recursive Length Prefix encoding written in Swift.
 * [AcknowledgementsPlist](https://github.com/cats-oss/AcknowledgementsPlist) - AcknowledgementsPlist manages the licenses of libraries that depend on your iOS app.
+* [CoreXLSX](https://github.com/MaxDesiatov/CoreXLSX) - Excel spreadsheet (XLSX) format support in pure Swift.
 
 
 ## Passbook


### PR DESCRIPTION
Thanks for this great list! Hope this library can be added to "Other Parsing" section.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/MaxDesiatov/CoreXLSX

## Category
Other Parsing

## Description
Excel spreadsheet (XLSX) format support in pure Swift

## Why it should be included to `awesome-ios` (mandatory)
To my knowledge `CoreXLSX` is the only open-source library available that provides Excel spreadsheet format support and has been recently updated and supports recent versions of Swift.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 Github stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English