### PR TITLE
Added CwlSignal to reactive programming topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,7 @@ Most of these are paid services, some have free tiers.
 * [RxReduce](https://github.com/RxSwiftCommunity/RxReduce) - Lightweight framework that ease the implementation of a state container pattern in a Reactive Programming compliant way.
 * [RxCoordinator](https://github.com/quickbirdstudios/XCoordinator) -  Powerful navigation library for iOS based on the coordinator pattern.
 * [RxAlamoRecord](https://github.com/Daltron/RxAlamoRecord) Combines the power of the AlamoRecord and RxSwift libraries to create a networking layer that makes interacting with API's easier than ever reactively.
+* [CwlSignal](https://github.com/mattgallagher/CwlSignal) A Swift framework for reactive programming.
 
 ### React-Like
 * [Render](https://github.com/alexdrone/Render) - Swift and UIKit a la React.


### PR DESCRIPTION
Adding one more library to reactive programming topic.

## Project URL
https://github.com/mattgallagher/CwlSignal

## Category
Reative programming

## Why it should be included to `awesome-ios` (mandatory)

Because it is a nice and lightweight library about reactive programming.