### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.4.1
 before_script:
   - gem install awesome_bot
   - gem install danger


### PR DESCRIPTION
Fixing the following error:
```
ERROR:  Error installing danger:
	There are no versions of kramdown (~> 2.0) compatible with your Ruby & RubyGems. Maybe try installing an older version of the gem you're looking for?
	kramdown requires Ruby version >= 2.3. The current ruby version is 2.2.0.
```