### PR TITLE
Add Accio to Dependency Manager section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2992,6 +2992,7 @@ CollectionView, make Instagram Discover within minutes.
 * [punic](https://github.com/schwa/punic) - Clean room reimplementation of Carthage tool
 * [Rome](https://github.com/blender/Rome) - A cache tool for Carthage built frameworks
 * [Athena](https://github.com/yunarta/works-athena-gradle-plugin) - Gradle Plugin to enhance Carthage by uploading the archived frameworks into Maven repository, currently support only Bintray, Artifactory and Mavel local.
+* [Accio](https://github.com/JamitLabs/Accio) - A SwiftPM based dependency manager for iOS & Co. with improvements over Carthage.
 
 ## Tools
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/JamitLabs/Accio

## Category
Dependency / Package Managers

## Description
I've added an entry for the new dependency manager Accio.

## Why it should be included to `awesome-ios` (mandatory)
It fixes many issues the community had with Carthage and is a good option going forward until SwiftPM is ready for iOS/tvOS/macOS/watchOS projects. It's ready for production by now as tested in several projects, has tests, including [these](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) integration tests which also ensure that many popular iOS/Swift frameworks support it. Also, it's gained a lot of traction in the last week consistently being in the top 10 of trending Swift projects on GitHub.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 Github stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
