### PR TITLE
Add SPStorkController

### DIFF
--- a/README.md
+++ b/README.md
@@ -2201,6 +2201,7 @@ Most of these are paid services, some have free tiers.
 * [SemiModalViewController](https://github.com/muyexi/SemiModalViewController) - Present view / view controller as bottom-half modal.
 * [ImageTransition](https://github.com/shtnkgm/ImageTransition) - ImageTransition is a library for smooth animation of images during transitions.
 * [LiquidTransition](https://github.com/AlexandrGraschenkov/LiquidTransition) - removes boilerplate code to perform transition, allows backward animations, custom properties animation and much more!
+* [SPStorkController](https://github.com/IvanVorobei/SPStorkController) - Very similar to the controllers displayed in Apple Music, Podcasts and Mail Apple's applications.
 
 ### Alert & Action Sheet
 


### PR DESCRIPTION
## Project URL
https://github.com/IvanVorobei/SPStorkController

## Category
UI/Animation/Transition

## Description
Very similar to the modal controller displayed in Apple Music, Podcasts and Mail apps. Customizable height of view. Check scroll's bounce for more interactive. Simple adding close button and centering arrow indicator. 

## Why it should be included to awesome-ios (mandatory)
It is an open source cocoapods with transition for controller that looks cool in apps. Easy customization. The author regularly updates the project.

## Checklist
- [x] Has 50 Github stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English