### PR TITLE
Added Semaphore CI for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3128,6 +3128,7 @@ CollectionView, make Instagram Discover within minutes.
 * [Instabug](https://instabug.com) - In-app feedback, Bug and Crash reporting, Fix Bugs Faster through user-steps, video recordings, screen annotation, network requests logging.
 * [Appfigurate](https://github.com/electricbolt/appfiguratesdk) - Secure runtime configuration for iOS and watchOS, apps and app extensions.
 * [ScreenshotFramer](https://github.com/IdeasOnCanvas/ScreenshotFramer) - With Screenshot Framer you can easily create nice-looking and localized App Store Images.
+* [Semaphore](https://semaphoreci.com/product/ios) - CI/CD service which makes it easy to build, test and deploy applications for any Apple device. iOS support is fully integrated in Semaphore 2.0, so you can use the same powerful CI/CD pipeline features for iOS as you do for Linux-based development.
 
 
 ## App Store


### PR DESCRIPTION
Added Semaphore CI for iOS

## Project URL
https://semaphoreci.com/product/ios

## Category
Deployment / Distribution

## Description
CI/CD service which makes it easy to build, test and deploy applications for any Apple device. iOS support is fully integrated with Semaphore 2.0, so you can use the same powerful CI/CD pipeline features for iOS as you do for Linux-based development.

## Why it should be included to `awesome-ios` (mandatory)

More details at [https://semaphoreci.com/blog/introducing-ios-cicd](https://semaphoreci.com/blog/introducing-ios-cicd)