### PR TITLE
Added TypedNotificationCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Futures](https://github.com/formbound/Futures) - Lightweight promises for iOS, macOS, tvOS, watchOS, and server-side Swift.
 * [EasyFutures](https://github.com/DimaMishchenko/EasyFutures) - 🔗 Swift Futures & Promises. Easy to use. Highly combinable.
 * [TopicEventBus](https://github.com/mcmatan/topicEventBus) - Publish–subscribe design pattern implementation framework, with ability to publish events by topic. (NotificationCenter extended alternative)
-* [TypedNotificationCenter](https://github.com/Cyberbeni/TypedNotificationCenter) - Typesafe rewrite of NSNotificationCenter, 100% code coverage, better performance than the original version
+* [TypedNotificationCenter](https://github.com/Cyberbeni/TypedNotificationCenter) - Typesafe rewrite of NSNotificationCenter, 100% code coverage, better performance than the original version.
 
 ## Files
 

--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Awesome-iOS is an amazing list for people who need a certain feature on their ap
 * [Futures](https://github.com/formbound/Futures) - Lightweight promises for iOS, macOS, tvOS, watchOS, and server-side Swift.
 * [EasyFutures](https://github.com/DimaMishchenko/EasyFutures) - 🔗 Swift Futures & Promises. Easy to use. Highly combinable.
 * [TopicEventBus](https://github.com/mcmatan/topicEventBus) - Publish–subscribe design pattern implementation framework, with ability to publish events by topic. (NotificationCenter extended alternative)
+* [TypedNotificationCenter](https://github.com/Cyberbeni/TypedNotificationCenter) - Typesafe rewrite of NSNotificationCenter, 100% code coverage, better performance than the original version
 
 ## Files
 


### PR DESCRIPTION
## Project URL
https://github.com/Cyberbeni/TypedNotificationCenter

## Category
EventBus

## Description
Added TypedNotificationCenter which is a typed version of Apple's NotificationCenter to avoid forgetting setting parameters in the userInfo dictionary and needing to handle not having those parameters.

## Why it should be included to `awesome-ios` (mandatory)
https://github.com/100mango/SwiftNotificationCenter is already in the list which is similar in a way that it tries to provide a typesafe alternative to NSNotificationCenter but has a different approach so both have their right to be in the list.
TypedNotificationCenter also has Travis CI to automatically run the tests on iOS, tvOS, macOS and Linux.

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
