### PR TITLE
Add Square In-App Payments for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,6 +1486,7 @@ Most of these are paid services, some have free tiers.
 * [Passkit](https://passkit.com) - Design, Create and validate Passbook Passes.
 
 ## Payments
+* [Square In-App Payments SDK](https://squareup.com/us/en/developers/in-app-payments) - Integrate Square payments into your mobile app with Digital wallet and stored card support for quick checkout.
 * [Caishen](https://github.com/prolificinteractive/Caishen) - A Payment Card UI & Validator for iOS.
 * [Stripe](https://stripe.com) - Payment integration on your app with PAY. Suitable for people with low knowledge on Backend.
 * [Braintree](https://www.braintreepayments.com) - Free payment processing on your first $50k. Requires Backend.


### PR DESCRIPTION
This adds [Square In-App Payments SDK](https://squareup.com/us/en/developers/in-app-payments) for iOS to the "Payments" category.

## Project URL
https://squareup.com/us/en/developers/in-app-payments

## Category
Payments

## Description
This adds Square's plugin for in-app payments to the Payments category.

## Why it should be included to `awesome-ios` (mandatory)
This plugin is simple to use to take payments with a credit card, Google Pay, Apple Pay, and stored card on file support for quick checkouts.

## Checklist
- [ X] Has 50 GitHub stargazers or more
- [ X] Only one project/change is in this pull request
- [ X] Isn't an archived project
- [ X] Has more than one contributor
- [ X] Has unit tests, integration tests or UI tests
- [ X] Addition in chronological order (bottom of category)
- [ X] Supports iOS 9 / tvOS 10 or later
- [ X] Supports Swift 4 or later
- [ X] Has a commit from less than 2 years ago
- [ X] Has a **clear** README in English
