### PR TITLE
Add AppStore card transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2195,6 +2195,7 @@ Most of these are paid services, some have free tiers.
 * [ImageTransition](https://github.com/shtnkgm/ImageTransition) - ImageTransition is a library for smooth animation of images during transitions.
 * [LiquidTransition](https://github.com/AlexandrGraschenkov/LiquidTransition) - removes boilerplate code to perform transition, allows backward animations, custom properties animation and much more!
 * [SPStorkController](https://github.com/IvanVorobei/SPStorkController) - Very similar to the controllers displayed in Apple Music, Podcasts and Mail Apple's applications.
+* [AppstoreTransition](https://github.com/appssemble/appstore-card-transition) - Simulates the appstore card animation transition.
 
 ### Alert & Action Sheet
 


### PR DESCRIPTION
Add AppstoreTransition

## Project URL
https://github.com/appssemble/appstore-card-transition

## Category
Transitions

## Description
Add this library to the list.

## Why it should be included to `awesome-ios` (mandatory)
It is a pretty useful, easy to use and good looking view controller transition.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English