### PR TITLE
nef - hard drugs for Xcode Playgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3062,6 +3062,7 @@ CollectionView, make Instagram Discover within minutes.
 * [Zolang](https://github.com/Zolang/Zolang) - A programming language for sharing logic between iOS, Android and Tools.
 * [xavtool](https://github.com/gabrielrobert/xavtool) - Command-line utility to automatically increase iOS / Android applications version.
 * [Cutter](https://cutter.albemala.me/) - A tool to generate iOS Launch Images (Splash Screens) for all screen sizes starting from a single template.
+* [nef](https://github.com/bow-swift/nef) - A set of command line tools for Xcode Playground: lets you have compile-time verification of your documentation written as Xcode Playgrounds, generates markdown files, integration with Jekyll for building microsites and Carbon to export code snippets.
 
 ## Rapid Development
 


### PR DESCRIPTION
## Project URL
https://github.com/bow-swift/nef

## Category
Tools

## Description
A set of command line tools for Xcode Playground: lets you have compile-time verification of your documentation written as Xcode Playgrounds, generates markdown files, integration with Jekyll for building microsites and Carbon to export code snippets.

## Why it should be included to `awesome-ios` (mandatory)
It is a cool tool to expand a lot the powerfull of Xcode Playgrounds. You can write documentation using Xcode Playgrounds markdown and using `nef` you can verify -from the command line- everything is working properly. 

It is not only you can do with `nef`. Additionally, `nef` provides the following features:

+ Eases the creation of Xcode Playgrounds with support for **third party libraries**.
+ **Compiles Xcode Playgrounds** with support for third-party libraries from the command line.
+ Generates **Markdown** project from Xcode Playground.
+ Generates Markdown files that can be consumed from **Jekyll for building a microsite**.
+ Export **Carbon** code snippets for given Xcode Playgrounds.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
