### PR TITLE
Add DWAlertController

### DIFF
--- a/README.md
+++ b/README.md
@@ -2263,6 +2263,7 @@ Most of these are paid services, some have free tiers.
 * [CatAlertController](https://github.com/ImKcat/CatAlertController) - Use UIAlertController like a boss.
 * [Loaf](https://github.com/schmidyy/Loaf) - A simple framework for easy iOS Toasts.
 * [SPAlert](https://github.com/IvanVorobei/SPAlert) - Native popup from Apple Music & Feedback in AppStore. Contains Done & Heart presets.
+* [DWAlertController](https://github.com/podkovyrin/DWAlertController) - UIAlertController reimplementation with controller containment support.
 
 ### Badge
 * [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons.


### PR DESCRIPTION
## Project URL
https://github.com/podkovyrin/DWAlertController

## Category
UI / Alert & Action Sheet

## Description
DWAlertController is an UIAlertController that supports displaying any view controller instead of title and message. DWAlertController fully copies the look and feel of UIAlertController and has the same API. Supported features: iPhone / iPad compatible, Dynamic Type, Accessibility, Dark Mode, rotation, tinting action buttons and many more.

## Why it should be included to `awesome-ios` (mandatory)
There were no UIAlertController implementations that support the customization of their content.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
