### PR TITLE
Updated siesta URL to the github one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1278,7 +1278,7 @@ Also see [push notifications](#push-notifications)
 * [NSRails](https://github.com/dingbat/nsrails) - iOS/Mac OS framework for Rails.
 * [NKMultipeer](https://github.com/nathankot/NKMultipeer) - A testable abstraction over multipeer connectivity.
 * [CocoaAsyncSocket](https://github.com/robbiehanson/CocoaAsyncSocket) - Asynchronous socket networking library for Mac and iOS.
-* [Siesta](https://bustoutsolutions.github.io/siesta/) - Elegant abstraction for RESTful resources that untangles stateful messes. An alternative to callback- and delegate-based networking.
+* [Siesta](https://github.com/bustoutsolutions/siesta) - Elegant abstraction for RESTful resources that untangles stateful messes. An alternative to callback- and delegate-based networking.
 * [Reachability.swift](https://github.com/ashleymills/Reachability.swift) - Replacement for Apple's Reachability re-written in Swift with closures
 * [OctopusKit](https://github.com/icoco/OctopusKit) - A simplicity but graceful solution for invoke RESTful web service APIs.
 * [Moya](https://github.com/Moya/Moya) - Network abstraction layer written in Swift.


### PR DESCRIPTION
Updated siesta URL to the github one, so https://awesome-repos.ecp.plus/ios.html and other similar sites can infer the star count and index it properly.

In case you want to detect this issue in other entries in the readme a regex that helps to find them is:

```
^(?!.*//github\.com).*https.*$
```