### PR TITLE
Removed Layer on Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,7 +1256,6 @@ Also see [push notifications](#push-notifications)
 * [XMPPFramework](https://github.com/robbiehanson/XMPPFramework) - An XMPP Framework in Objective-C for Mac and iOS.
 * [Chatto](https://github.com/badoo/Chatto) - A lightweight framework to build chat applications, made in Swift
 * [MessageKit](https://github.com/MessageKit/MessageKit) - Eventually, a Swift re-write of JSQMessagesViewController
-* [Atlas](https://github.com/layerhq/Atlas-iOS) - A library of native iOS messaging user interface components for Layer.
 * [Messenger](https://github.com/relatedcode/Messenger) - This is a native iOS Messenger app, making realtime chat conversations and audio calls with full offline support.
 * [OTTextChatAccelerator](https://github.com/opentok/accelerator-textchat-ios) - OpenTok Text Chat Accelerator Pack enables text messages between mobile or browser-based devices.
 * [chat-sdk-ios](https://github.com/chat-sdk/chat-sdk-ios) - Chat SDK iOS - Open Source Mobile Messenger.


### PR DESCRIPTION
Layer has officially shutdown last October 30, 2019.

## Project URL
https://github.com/layerhq/releases-ios
https://layer.com/

## Category
Messaging

## Description
Layer has officially shutdown last October 30, 2019. I removed the library in the listing

<img width="1552" alt="Screen Shot 2019-10-04 at 8 19 29 AM" src="https://user-images.githubusercontent.com/17846698/66173105-26f0dd80-e681-11e9-85bf-72c3c490cd1a.png">

