### PR TITLE
Add Squid - Networking and WebSocket Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,7 @@ Also see [push notifications](#push-notifications)
 * [MHNetwork](https://github.com/emadhegab/MHNetwork) - Protocol Oriented Network Layer Aim to avoid having bloated singleton NetworkManager
 * [ThunderRequest](https://github.com/3sidedcube/ThunderRequest) - A simple URLSession wrapper with a generic protocol based request body approach and easy deserialisation of responses.
 * [ReactiveAPI](https://github.com/sky-uk/ReactiveAPI) - Write clean, concise and declarative network code relying on URLSession, with the power of RxSwift. Inspired by Retrofit.
+* [Squid](https://github.com/borchero/Squid) - Declarative and reactive networking framework based on Combine and providing means for HTTP requests, transparent pagination, and WebSocket communication.
 
 ### Email
 
@@ -2966,6 +2967,7 @@ CollectionView, make Instagram Discover within minutes.
 * [SwifterSockets](https://github.com/Balancingrock/SwifterSockets) - A collection of socket utilities in Swift for OS-X and iOS
 * [Swift-ActionCableClient](https://github.com/danielrhodes/Swift-ActionCableClient) - ActionCable is a new WebSocket server being released with Rails 5 which makes it easy to add real-time features to your app.
 * [DNWebSocket](https://github.com/GlebRadchenko/DNWebSocket) - Object-Oriented, Swift-style WebSocket Library (RFC 6455) for Swift-compatible Platforms.
+* [Squid](https://github.com/borchero/Squid) - WebSocket library based on Combine where requests are handled very similarly to usual HTTP requests.
 
 ## Project setup
 * [crafter](https://github.com/krzysztofzablocki/crafter) - CLI that allows you to configure iOS project's template using custom DSL syntax, simple to use and quite powerful.

--- a/README.md
+++ b/README.md
@@ -2967,7 +2967,6 @@ CollectionView, make Instagram Discover within minutes.
 * [SwifterSockets](https://github.com/Balancingrock/SwifterSockets) - A collection of socket utilities in Swift for OS-X and iOS
 * [Swift-ActionCableClient](https://github.com/danielrhodes/Swift-ActionCableClient) - ActionCable is a new WebSocket server being released with Rails 5 which makes it easy to add real-time features to your app.
 * [DNWebSocket](https://github.com/GlebRadchenko/DNWebSocket) - Object-Oriented, Swift-style WebSocket Library (RFC 6455) for Swift-compatible Platforms.
-* [Squid](https://github.com/borchero/Squid) - WebSocket library based on Combine where requests are handled very similarly to usual HTTP requests.
 
 ## Project setup
 * [crafter](https://github.com/krzysztofzablocki/crafter) - CLI that allows you to configure iOS project's template using custom DSL syntax, simple to use and quite powerful.


### PR DESCRIPTION
Added the [Squid](https://github.com/borchero/Squid) library to the *Networking* and *Websocket* sections.

## Project URL

https://github.com/borchero/Squid

## Category

Networking & Websocket

## Description

Added two entries to the list in README.md.

## Why it should be included to `awesome-ios` (mandatory)

Squid has been designed specifically for being used with Apple's Combine framework. It is therefore tightly integrated with latest features that have been enabled with the advent of Swift 5. As one of the first projects that is focused on the application of Combine, and considering that documentation for Combine is currently sparse, it also serves as a useful reference implementation for writing highly customized publishers.

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
