### PR TITLE
nef - Xcode Editor Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -3154,6 +3154,7 @@ CollectionView, make Instagram Discover within minutes.
 * [Snowonder](https://github.com/Karetski/Snowonder) - 🔮 Magical import declarations formatter for Xcode.
 * [XVim2](https://github.com/XVimProject/XVim2) - Vim key-bindings for Xcode 9.
 * [Comment Spell Checker](https://github.com/velyan/Comment-Spell-Checker) - Xcode extension for spell checking and auto correcting code comments.
+* [nef](https://github.com/bow-swift/nef-plugin) - This Xcode extension enables you to make a code selection and export it to a snippets. Available on Mac AppStore.
 
 ### Themes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/bow-swift/nef-plugin

## Category
Extensions (Xcode 8+)

## Description
This project provides an extension for Xcode to integrate some nef features directly in the IDE. Using the core of nef, you can export snippets from your code selection directly in Xcode.

## Why it should be included to `awesome-ios` (mandatory)
You know all of those code screenshots you see on social networks, or at meetups and conferences? Do you want to share images of your code with your team? This Xcode extension makes it easy to create and share beautiful images of your source code.

## Checklist
- [ ] Has 50 GitHub stargazers or more (it has been launched today but is under umbrella another repository, and it has more than 50 stars - https://github.com/bow-swift/nef)
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
