### PR TITLE
Add OpenCombine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,6 +1579,7 @@ Most of these are paid services, some have free tiers.
 - [CwlSignal](https://github.com/mattgallagher/CwlSignal) A Swift framework for reactive programming.
 - [LightweightObservable](https://github.com/fxm90/LightweightObservable) - A lightweight implementation of an observable sequence that you can subscribe to.
 - [Bindy](https://github.com/MaximKotliar/Bindy) - Simple, lightweight swift bindings with KVO support and easy to read syntax.
+- [OpenCombine](https://github.com/broadwaylamb/OpenCombine) — Open source implementation of Apple's Combine framework for processing values over time.
 
 ### React-Like
 - [Render](https://github.com/alexdrone/Render) - Swift and UIKit a la React.


### PR DESCRIPTION
## Project URL
https://github.com/broadwaylamb/OpenCombine

## Category
Reactive Programming

## Description
Open source implementation of Apple's Combine framework for processing values over time.

## Why it should be included to `awesome-ios` (mandatory)
There's a demand in the community for using Combine on iOS versions less than iOS 13.0. This library satisfies that demand by providing a well-tested, performant and portable implementation of Combine with the number one goal to fully match Combine's semantics.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
