### PR TITLE
Add Clean Architecture demo app with ViewInspector library

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [VIPER Module Generator](https://github.com/Kaakati/VIPER-Module-Generator) - A Clean VIPER Modules Generator with comments and predfined functions.
 - [MMVMi](https://github.com/Maryom/MMVMi) - A Validation Model for MVC and MVVM Design Patterns in iOS Applications.
 - [ios-architecture](https://github.com/tailec/ios-architecture) - A collection of iOS architectures - MVC, MVVM, MVVM+RxSwift, VIPER, RIBs and many others.
+- [Clean Architecture for SwiftUI](https://github.com/nalexn/clean-architecture-swiftui) - SwiftUI demo project built with Clean Architecture. Offers 97% test coverage and programmatic navigation support
 
 ## ARKit
 
@@ -1880,6 +1881,7 @@ Most of these are paid services, some have free tiers.
 - [Flawless App](https://flawlessapp.io/) - tool for visual quality check of mobile app in a real-time. It compares initial design with the actual implementation right inside iOS simulator.
 - [TouchVisualizer](https://github.com/morizotter/TouchVisualizer) - Lightweight touch visualization library in Swift. A single line of code and visualize your touches!
 - [UITestHelper](https://github.com/evermeer/UITestHelper) - UITest helper library for creating readable and maintainable tests.
+- [ViewInspector](https://github.com/nalexn/ViewInspector) - Runtime inspection and unit testing of SwiftUI views
 
 ### Other Testing
 - [NaughtyKeyboard](https://github.com/Palleas/NaughtyKeyboard) - The Big List of Naughty Strings is a list of strings which have a high probability of causing issues when used as user-input data. This is a keyboard to help you test your app from your iOS device.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/nalexn/clean-architecture-swiftui
https://github.com/nalexn/ViewInspector

## Category
Architecture Patterns and UI Testing

## Description
**Clean Architecture SwiftUI** demo project has been created a month ago but has already generated 80 stars. It has 97% test coverage and Codebeat "A" code quality. The project is a demo app that showcases the setup of a cross-platform SwiftUI app with Clean Architecture
**ViewInspector** is a brand new repo (created a week ago), which already received 40 stars and keeps rapidly growing. This is the very first Unit Testing framework of its kind, offering runtime inspection of black-boxed SwiftUI views.

## Why it should be included to `awesome-ios` (mandatory)
I believe both projects can offer essential help for the developers getting started or intensively using the SwiftUI, which is the future of the UI development for Apple's platforms

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [ ] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
