### PR TITLE
Add ModuleInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [Crayon](https://github.com/luoxiu/Crayon) - Terminal string styling with expressive api and 256/TrueColor support.
 - [SwiftShell](https://github.com/kareman/SwiftShell) - A Swift framework for shell scripting and running shell commands.
 - [SourceDocs](https://github.com/eneko/SourceDocs) - Command Line Tool that generates Markdown documentation from inline source code comments.
+- [ModuleInterface](https://github.com/minuscorp/ModuleInterface) - Command Line Tool that generates the Module's Interface from a Swift project.
 
 ## Concurrency
 


### PR DESCRIPTION
I've aded a reference to the ModuleInterface project
## Project URL
https://github.com/minuscorp/ModuleInterface

## Category
CommandLine

## Description
I've added a line at the end of the Command Line tools section with a reference of the lib.

## Why it should be included to `awesome-ios` (mandatory)
It is the unique library out there capable of generate Module Interfaces like Xcode does once CMD + click an `import` statement. Useful for documentation purposes of projects and libraries. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
