### PR TITLE
Added Speculid

### DIFF
--- a/README.md
+++ b/README.md
@@ -3073,6 +3073,7 @@ Most of these are paid services, some have free tiers.
 - [xavtool](https://github.com/gabrielrobert/xavtool) - Command-line utility to automatically increase iOS / Android applications version.
 - [Cutter](https://cutter.albemala.me/) - A tool to generate iOS Launch Images (Splash Screens) for all screen sizes starting from a single template.
 - [nef](https://github.com/bow-swift/nef) - A set of command line tools for Xcode Playground: lets you have compile-time verification of your documentation written as Xcode Playgrounds, generates markdown files, integration with Jekyll for building microsites and Carbon to export code snippets.
+- [Speculid](https://speculid.com) - generate Image Sets and App Icons from SVG, PNG, and JPEG files
 
 ## Rapid Development
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://speculid.com

## Category
Tools

## Description
Added Speculid to the Tools section for creating app icons and image sets from SVG files

## Why it should be included to `awesome-ios` (mandatory)
Open-Source Swift Mac App for creating App Icons and Image Sets in from single SVG files. Includes the option for specifying sizes for Image Sets, creating PDF for vector images in Image Sets, removing alpha channel and setting background colors for app icons. Can be installed via homebrew and built with Xcode.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
