### PR TITLE
Added NFCPassportReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [Device.swift](https://github.com/schickling/Device.swift) - Super-lightweight library to detect used device.
 - [SDVersion](https://github.com/sebyddd/SDVersion) - Lightweight Cocoa library for detecting the running device's model and screen size.
 - [Haptico](https://github.com/iSapozhnik/Haptico) - Easy to use haptic feedback generator with pattern-play support.
+- [NFCPassportReader](https://github.com/AndyQ/NFCPassportReader) - Swift library  to read an NFC enabled passport. Supports BAC, Secure Messaging, and both active and passive authentication. Requires iOS 13 or above.
 
 ## Layout
 


### PR DESCRIPTION
## Project URL
https://github.com/AndyQ/NFCPassportReader

## Category
Hardware / Other Hardware

## Description
Reads an NFCEnabledPassport on an iOS 13 device.  Supports BAC, Secure Messaging, both active and passive authentication, and supports all the major DataGroups.

## Why it should be included to `awesome-ios` (mandatory)
There is no other component that can read an NFC enabled passport.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
