### PR TITLE
Adding PrivacyFlash Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2887,6 +2887,7 @@ Most of these are paid services, some have free tiers.
 
 ## User Consent
 - [SmartlookConsentSDK](https://github.com/smartlook/ios-consent-sdk) - Open source SDK which provides a configurable control panel where user can select their privacy options and store the user preferences for the app.
+- [PrivacyFlash Pro](https://github.com/privacy-tech-lab/privacyflash-pro) - Generate a privacy policy for your iOS app from its code
 
 ## VR
 - [VR Toolkit iOS](https://github.com/Aralekk/VR_Toolkit_iOS) - A sample project that provides the basics to create an interactive VR experience on iOS.


### PR DESCRIPTION
With PrivacyFlash Pro developers can generate a privacy policy for their iOS app from its code. PrivacyFlash Pro is based on an academic research project at Wesleyan University.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/privacy-tech-lab/privacyflash-pro

## Category
<!--- Category in AwesomeiOS where the project will be added -->
Consent

## Description
<!--- Describe your changes in detail -->
Add PrivacyFlash Pro to the readme

## Why it should be included to `awesome-ios` (mandatory)
PrivacyFlash Pro is a privacy policy generator for iOS apps written in Swift. It helps developers to create meaningful privacy policies by automatically analyzing app code. It also guides developers through a wizard questionnaire covering policy provisions that cannot be detected from the app code (e.g., how long data is retained). PrivacyFlash Pro is intended to increase privacy transparency in the iOS app ecosystem.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
