### PR TITLE
Add Developer Disk Images to XCode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3151,6 +3151,7 @@ Most of these are paid services, some have free tiers.
 - [Xcode Keymap for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stevemoser.xcode-keybindings) - This extension ports popular Xcode keyboard shortcuts to Visual Studio Code.
 - [Xcode Template Manager](https://github.com/Camji55/xtm) - Xcode Template Manager is a Swift command line tool that helps you manage your Xcode project templates.
 - [VIPER Module Template](https://github.com/EvsenevDev/VIPERModuleTemplate) - Xcode Template of VIPER Module which generates all layers of VIPER.
+- [XCode Developer Disk Images](https://github.com/haikieu/xcode-developer-disk-image-all-platforms) - Xcode Developer Disk Images is needed when you want to put your build to the device, however sometimes your XCode is not updated with the latest Disk Images, you could find them here for convenience.
 
 ## Reference
 - [Swift Cheat Sheet](https://github.com/iwasrobbed/Swift-CheatSheet) - A quick reference cheat sheet for common, high level topics in Swift.

--- a/README.md
+++ b/README.md
@@ -3151,7 +3151,7 @@ Most of these are paid services, some have free tiers.
 - [Xcode Keymap for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stevemoser.xcode-keybindings) - This extension ports popular Xcode keyboard shortcuts to Visual Studio Code.
 - [Xcode Template Manager](https://github.com/Camji55/xtm) - Xcode Template Manager is a Swift command line tool that helps you manage your Xcode project templates.
 - [VIPER Module Template](https://github.com/EvsenevDev/VIPERModuleTemplate) - Xcode Template of VIPER Module which generates all layers of VIPER.
-- [XCode Developer Disk Images](https://github.com/haikieu/xcode-developer-disk-image-all-platforms) - Xcode Developer Disk Images is needed when you want to put your build to the device, however sometimes your XCode is not updated with the latest Disk Images, you could find them here for convenience.
+- [Xcode Developer Disk Images](https://github.com/haikieu/xcode-developer-disk-image-all-platforms) - Xcode Developer Disk Images is needed when you want to put your build to the device, however sometimes your Xcode is not updated with the latest Disk Images, you could find them here for convenience.
 
 ## Reference
 - [Swift Cheat Sheet](https://github.com/iwasrobbed/Swift-CheatSheet) - A quick reference cheat sheet for common, high level topics in Swift.


### PR DESCRIPTION
## Project URL
https://github.com/haikieu/xcode-developer-disk-image-all-platforms

## Category
XCode-other

## Description
Add Developer Disk Images item to XCode-other section 

## Why it should be included to `awesome-ios` (mandatory)
Xcode Developer Disk Images is needed when you want to put your build to the device, however sometimes XCode is not updated with the latest Disk Images, you could find them here for convenience.

## Checklist
- [Not to close] Has 50 GitHub stargazers or more
- [X ] Only one project/change is in this pull request
- [X ] Isn't an archived project
- [Will have more contributor in the future] Has more than one contributor
- [Not Applicable] Has unit tests, integration tests or UI tests
- [X ] Addition in chronological order (bottom of category)
- [Not Applicable ] Supports iOS 9 / tvOS 10 or later
- [Not Applicable ] Supports Swift 4 or later
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English