### PR TITLE
Add GaugeSlider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2569,6 +2569,7 @@ Most of these are paid services, some have free tiers.
 - [MultiSlider](https://github.com/yonat/MultiSlider) - UISlider clone with multiple thumbs and values, optional snap intervals, optional value labels.
 - [AGCircularPicker](https://github.com/agilie/AGCircularPicker) - AGCircularPicker is helpful component for creating a controller aimed to manage any calculated parameter.
 - [Fluid Slider](https://github.com/Ramotion/fluid-slider) - A slider widget with a popup bubble displaying the precise value selected.
+- [GaugeSlider](https://github.com/edgar-zigis/GaugeSlider) - A highly customizable GaugeSlider designed for a Smart Home application.
 
 ### Splash View
 - [CBZSplashView](https://github.com/callumboddy/CBZSplashView) - Twitter style Splash Screen View. Grows to reveal the Initial view behind.


### PR DESCRIPTION
## Project URL
https://github.com/edgar-zigis/GaugeSlider

## Category
Slider

## Description
Highly customizable GaugeSlider designed for a Smart Home app.

## Why it should be included to `awesome-ios` (mandatory)
It is unique and has no analog design. It has been also featured at Medium, so it's not that bad :)

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
