### PR TITLE
Add SDLoopingVideoView to Video section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,6 +1254,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [swift-360-videos](https://github.com/gsabran/DDDKit) - Pure swift (no SceneKit) 3D library with focus on video and 360.
 - [ABMediaView](https://github.com/andrewboryk/ABMediaView) - UIImageView subclass for drop-in image, video, GIF, and audio display, with functionality for fullscreen and minimization to the bottom-right corner.
 - [PryntTrimmerView](https://github.com/HHK1/PryntTrimmerView) - A set of UI elements to trim, crop and select frames inside a video.
+- [SDLoopingVideoView](https://github.com/SolsmaHawk/SDLoopingVideoView) - A looping video background view that dynamically switches videos between dark and light user interface modes.
 - [VGPlayer](https://github.com/VeinGuo/VGPlayer) - A simple iOS video player in Swift,Support play local and network,Background playback mode.
 - [YoutubeKit](https://github.com/rinov/YoutubeKit) - A video player that fully supports Youtube IFrame API and YoutubeDataAPI for easily create a Youtube app.
 - [Swift-YouTube-Player](https://github.com/gilesvangruisen/Swift-YouTube-Player) - Swift library for embedding and controlling YouTube videos in your iOS applications!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/SolsmaHawk/SDLoopingVideoView

## Category
Video

## Description
SDLoopingVideoView is a looping video-view based off of AVPlayerLayer; it works great when used as a video background and automatically scales any video displayed to aspect-fill the view you define or can bet set manually. SDLoopingVideoView supports setting a unique video for both dark and light ui modes and switches between them dynamically. SDLoopingVideoView responds to any UIView animations and scales accordingly without interruption of the video playing.

## Why it should be included to `awesome-ios` (mandatory)
SDLoopingVideoView is an easy way to add a looping video as a background in your project. It uniquely supports videos for dark and light ui modes and switches videos dynamically when users change userInterfaceMode.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
