### PR TITLE
Add CodableCSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,6 +1416,7 @@ Most of these are paid services, some have free tiers.
 ### CSV
 - [CSwiftV](https://github.com/Daniel1of1/CSwiftV) - A csv parser written in swift conforming to rfc4180.
 - [CSV.swift](https://github.com/yaslab/CSV.swift) - CSV reading and writing library written in Swift.
+- [CodableCSV](https://github.com/dehesa/CodableCSV) - Read and write CSV files row-by-row & field-by-field or through Swift's Codable interface.
 
 ### JSON
 - [SBJson](https://github.com/SBJson/SBJson) - This framework implements a strict JSON parser and generator in Objective-C.


### PR DESCRIPTION
I have added [`CodableCSV`](https://github.com/dehesa/CodableCSV) to the [Parsing](https://github.com/vsouza/awesome-ios#parsing) [CSV](https://github.com/vsouza/awesome-ios#csv) category.

## Project URL
https://github.com/dehesa/CodableCSV

## Category
Parsing - CSV

## Description
Added a new entry on the CSV subcategory.

## Why it should be included to `awesome-ios` (mandatory)
`CodableCSV` provides imperative CSV readers/writers and most importantly adopts the `Codable` interface. By mirroring Foundation's JSON & PLIst encoder/decoder strategies, it makes it a breeze for any developer to use simple & complex CSV structures.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English