### PR TITLE
add CloudCore to Core Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [PrediKit](https://github.com/KrakenDev/PrediKit) - An NSPredicate DSL for iOS, macOS, tvOS, & watchOS. Inspired by SnapKit and lovingly written in Swift.
 - [Records](https://github.com/BowdusBrown/Records) - In just a few minutes, setup a fully functioning CoreData implementation that embraces the static, type-safe nature of Swift.
 - [PredicateFlow](https://github.com/andreadelfante/PredicateFlow) - Write amazing, strong-typed and easy-to-read NSPredicate, allowing you to write flowable NSPredicate, without guessing attribution names, predicate operation or writing wrong arguments type.
+- [CloudCore](https://github.com/deeje/CloudCore) - Robust CloudKit synchronization: offline editing, relationships, shared and public databases, field-level deltas, and more.
 
 ## Database
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/deeje/CloudCore

## Category
Core Data

## Description
Robust CloudKit synchronization: offline editing, relationships, shared and public databases, field-level deltas, and more.

## Why it should be included to `awesome-ios` (mandatory)
I took over the project from another developer, and continue to refine it, adding support for offline editing (via NSPersistentHistoryTracking) as well as support for all three databases in CloudKit. The repository ReadMe has a comparison with Apple's built in CloudKit sync engine to show all the features and benefits of CloudCore. I'll be rolling out support for watchOS soon.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
