### PR TITLE
add Matft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [Expression](https://github.com/nicklockwood/Expression) - A Mac and iOS library for evaluating numeric expressions at runtime.
 - [Metron](https://github.com/toineheuvelmans/Metron) - Metron is a comprehensive collection of geometric functions and types that extend the 2D geometric primitives provided by CoreGraphics.
 - [NumericAnnex](https://github.com/xwu/NumericAnnex) - NumericAnnex supplements the numeric facilities provided in the Swift standard library.
+- [Matft](https://github.com/jjjkkkjjj/Matft) - Matft is Numpy-like library in Swift. Matft allows us to handle n-dimensional array easily in Swift.
 
 ## Media
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Matft is Numpy-like library in Swift.

## Project URL
<!--- The project URL -->
[https://github.com/jjjkkkjjj/Matft](https://github.com/jjjkkkjjj/Matft)

## Category
<!--- Category in AwesomeiOS where the project will be added -->
Math

## Description
<!--- Describe your changes in detail -->
Matft is Numpy-like library in Swift. Matft allows us to handle n-dimensional array easily in Swift.

## Why it should be included to `awesome-ios` (mandatory)
Matft seems to be one of the most useful Numpy-like library in Swift. Because Matft allows us to handle n-dimensional array easily in Swift. Furthermore, those n-dimensional array(MfArray) can be converted into various types (such as int, float, double, bool and so on: see [details](https://github.com/jjjkkkjjj/Matft#mftype)). Also MfArray keeps high-performance (see [details](https://github.com/jjjkkkjjj/Matft#performance)) thanks to integrating Accelerate framework. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
