### PR TITLE
Add SheetyColors

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Mobile teams accelerate their workflows by seamlessly integrating with third-par
 - [ChromaColorPicker](https://github.com/joncardasis/ChromaColorPicker) - An intuitive iOS color picker built in Swift.
 - [Lorikeet](https://github.com/valdirunars/Lorikeet) - A lightweight Swift framework for aesthetically pleasing color-scheme generation and CIE color-difference calculation.
 - [Gestalt](https://github.com/regexident/Gestalt) - An unintrusive & light-weight iOS app-theming library with support for animated theme switching.
+- [SheetyColors](https://github.com/chrs1885/SheetyColors) - An action sheet styled color picker for iOS.
 
 ## Command Line
 


### PR DESCRIPTION
Added SheetyColors library (iOS color picker) to the Colors section.

## Project URL
https://github.com/chrs1885/SheetyColors

## Category
Colors

## Description
Added the library entry to README.MD

## Why it should be included to `awesome-ios` (mandatory)
Because Apple doesn't provide any built in solution for iOS.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
