### PR TITLE
Add CodeMirror Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,7 @@ Most of these are paid services, some have free tiers.
 - [EFMarkdown](https://github.com/EFPrefix/EFMarkdown) - A lightweight Markdown library for iOS.
 - [Croc](https://github.com/jkalash/croc) - A lightweight Swift library for Emoji parsing and querying.
 - [PostalCodeValidator](https://github.com/FormatterKit/PostalCodeValidator) - A validator for postal codes with support for 200+ regions.
+- [CodeMirror Swift](https://github.com/ProxymanApp/CodeMirror-Swift) - A lightweight wrapper of CodeMirror for macOS and iOS. Support Syntax Highlighting & Themes. 
 
 ### Font
 - [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app.


### PR DESCRIPTION
Add CodeMirror-Swift to Text Section

## Project URL
https://github.com/ProxymanApp/CodeMirror-Swift

## Category
Text

## Description
CodeMirror-Swift is a lightweight CodeMirror Wrapper for macOS and iOS. It includes built-in syntax highlighting, add-ons, and themes.

## Why it should be included to `awesome-ios` (mandatory)
Lack of open-source library that supports full-features for Editor including syntax highlighting on macOS and iOS. Additionally, it's a lightweight wrapper and high customizable for the end developers. The repo is suitable for Markdown, Data Previewer, or Text Editor.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
