### PR TITLE
Add SwiftWebImage into Image category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,7 @@
 - [UIImage DSP](https://github.com/gdawg/uiimage-dsp) - iOS UIImage processing functions using the vDSP/Accelerate framework for speed.
 - [AsyncImageView](https://github.com/nicklockwood/AsyncImageView) - Simple extension of UIImageView for loading and displaying images asynchronously without lock up the UI.
 - [SDWebImage](https://github.com/SDWebImage/SDWebImage) - Asynchronous image downloader with cache support with an UIImageView category.
+- [SwiftWebImage](https://github.com/geekaurora/SwiftWebImage) - 🚀SwiftUI Image downloader with performant LRU mem/disk cache.
 - [DFImageManager](https://github.com/kean/DFImageManager) - Modern framework for fetching images from various sources. Zero config yet immense customization and extensibility. Uses NSURLSession.
 - [MapleBacon](https://github.com/JanGorman/MapleBacon) - An image download and caching library for iOS written in Swift.
 - [NYTPhotoViewer](https://github.com/NYTimes/NYTPhotoViewer) - Slideshow and image viewer.


### PR DESCRIPTION
Add SwiftWebImage into Image category.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/geekaurora/SwiftWebImage

## Category
Image

## Description
🚀SwiftUI Image downloader with performant LRU mem/disk cache.

## Why it should be included to `awesome-ios` (mandatory)

None of existing Image downloading libraries support ImageView `config` well for SwiftUI, includes SDWebImage, Kingfisher, but `SwiftWebImage` does.

Progressive concurrent image downloader for SwiftUI, with neat API and performant LRU mem/disk cache. 
 
#### Simple Usage

Just `import SwiftWebImage` and set `url` for `SwiftImage`:

```swift
SwiftImage<Image>(imageUrl)                   
```

Framework will automatically load Image with `@ObservedObject` data once download completes.

#### How to config ImageView? 
Trailing `config` closure of `SwiftImage` is used for underlying ImageView configuration:

```swift
SwiftImage(imageUrl) { imageView in
  imageView
    .resizable()
    .aspectRatio(1, contentMode: .fit)
}
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
