### PR TITLE
Add ImageUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,6 +1202,7 @@
 - [OnlyPictures](https://github.com/KiranJasvanee/OnlyPictures) - A simple and flexible way to add source of overlapping circular pictures.
 - [SFSafeSymbols](https://github.com/piknotech/SFSafeSymbols) - Safely access Apple's SF Symbols using static typing.
 - [BSZoomGridScrollView](https://github.com/boraseoksoon/BSZoomGridScrollView) - iOS customizable grid style scrollView UI library to display your UIImage array input, designed primarily for SwiftUI as well as to interoperate with UIKit.
+- [ImageUI](https://github.com/alberto093/ImageUI) - A photo browser inspired by Apple Photos app.
 
 ### Media Processing
 - [SwiftOCR](https://github.com/garnele007/SwiftOCR) - Fast and simple OCR library written in Swift.


### PR DESCRIPTION
##  Project URL
https://github.com/alberto093/ImageUI

## Category
Image

## Description
ImageUI is an open source project for displaying images and videos (not yet implemented) in a similar way to Apple’s Photos app. In this version there is the photo browser that allows to display thumbnail and full-size images.

## Why it should be included to `awesome-ios` (mandatory)

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
