### PR TITLE
Added Previewed.app to list of AppStore resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3110,6 +3110,7 @@ Most of these are paid services, some have free tiers.
 - [Siren](https://github.com/ArtSabintsev/Siren) - Notify users when a new version of your app is available and prompt them to upgrade.
 - [Appstore Review Guidelines](https://github.com/aashishtamsya/Appstore-Review-Guidelines) - A curated list of points which a developer has to keep in mind before submitting his/her application on appstore for review.
 - [AppVersion](https://github.com/amebalabs/AppVersion) - Keep users on the up-to date version of your App.
+- [Previewed](https://previewed.app) - Create screenshots and preview video of your app for AppStore.
 
 
 ## Xcode


### PR DESCRIPTION
Creator here, added Previewed.app as a list of resources.

## Project URL
https://previewed.app

## Category
AppStore

## Description
As per contributor guide, added a link to previewed.app in the specified format.

## Why it should be included to `awesome-ios` (mandatory)
It's a tool that aims to save a lot of time for devs during the distribution/deployment process. So far, we gathered amazing feedback from the community and constantly release new features. You can create videos / screenshots in just a few clicks. 

## Checklist
It's a 3rd party library service, for iOS devs.

- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago


Hopefully it saves you time!
