### PR TITLE
Add Classpert courses to section “Courses”

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@
 - [Udemy - ARKit - Beginner to Professional in Swift 4 and iOS 11](https://www.udemy.com/course/arkit-beginner-to-professional/)
 - [ARStarter](https://github.com/codePrincess/ARStarter) - Get started with ARKit - A little exercise for beginners.
 - [iOS 13 & Swift 5 - The Complete iOS App Development Bootcamp](https://www.udemy.com/course/ios-13-app-development-bootcamp/)
-
+- [Classpert - A list of 500 iOS Development courses (free and paid), from top e-learning platforms](https://classpert.com/ios-development) - Complete catalog of courses from Udacity, Pluralsight, Coursera, Edx, Treehouse and Skillshare.
 ## Accessibility
 
  *Frameworks that help to support accessibility features and enable people with disabilities to use your app*


### PR DESCRIPTION
## Project URL
[https://classpert.com/ios-development](https://classpert.com/ios-development)

## Category
Courses

## Description
This commit adds Classpert to the section “Courses”, with a comprehensive selection of almost 500 iOS Development courses (free and paid) from top e-learning providers like Udacity, Coursera, Pluralsight, Udemy, Edx, Treehouse, and Skillshare.

## Why it should be included to `awesome-ios` (mandatory)
Classpert unites courses from all major e-learning platforms and many of them are free. This tool is also extremely helpful for people searching and comparing online courses in one place, before deciding which one to take

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [ x] Only one project/change is in this pull request
- [ x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
