### PR TITLE
Add FDSoundActivatedRecorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,6 +1090,7 @@
 - [Voice Overlay](https://github.com/algolia/voice-overlay-ios) - An overlay that gets your user’s voice permission and input as text in a customizable UI.
 - [ModernAVPlayer](https://github.com/noreasonprojects/ModernAVPlayer) - Persistence player to resume playback after bad network connection even in background mode, manage headphone interactions, system interruptions, now playing informations and remote commands.
 - [FDWaveformView](https://github.com/fulldecent/FDWaveformView) - An easy way to display an audio waveform in your app, including animation.
+- [FDSoundActivatedRecorder](https://github.com/fulldecent/FDSoundActivatedRecorder) - Start recording when the user speaks.
 
 ### GIF
 


### PR DESCRIPTION
## Project URL
https://github.com/fulldecent/FDSoundActivatedRecorder

## Category
Audio

## Description
Start recording when the user speaks. All you have to do is tell us when to start listening. Then we wait for an audible noise and start recording. This is mostly useful for user speech input and the "Start talking now" prompt.

## Why it should be included to `awesome-ios` (mandatory)
Because Siri knows when to start and stop listening. So your app should too.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more -- 17
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
