### PR TITLE
Add SwiftUI-FontIcon lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1823,6 +1823,7 @@ Most of these are paid services, some have free tiers.
 - [Font-Awesome-Swift](https://github.com/Vaberer/Font-Awesome-Swift) - Font Awesome swift library for iOS.
 - [JQSwiftIcon](https://github.com/josejuanqm/JQSwiftIcon) - Icon Fonts on iOS using string interpolation written in Swift.
 - [Money](https://github.com/Flight-School/Money) - A precise, type-safe representation of a monetary amount in a given currency.
+- [SwiftUI-FontIcon](https://github.com/huybuidac/SwiftUIFontIcon) - Icons fonts for SwiftUI (FontAwesome, Ionicon, MaterialIcon).
 
 ## Testing
 


### PR DESCRIPTION
Add SwiftUI-FontIcon lib

## Project URL
https://github.com/huybuidac/SwiftUIFontIcon

## Category
Fonts

## Description
Font Icons for SwiftUI - FontAwesome, Ionicons, Material icons

## Why it should be included to `awesome-ios` (mandatory)
It supports many font icons and makes SwiftUI development easier.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
