### PR TITLE
Added mobiledeveloperscafe.com newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3260,6 +3260,7 @@ Most of these are paid services, some have free tiers.
 - [Server-Side Swift Weekly](https://www.serverswift.tech) - A weekly newsletter with the best links related to server-side Swift and cross-platform developer tools. Curated by [@maxdesiatov](https://twitter.com/maxdesiatov)
 - [iOS Cookies Newsletter](https://us11.campaign-archive.com/home/?u=cd1f3ed33c6527331d82107ba&id=532dc7fb64) - A weekly digest of new iOS libraries written in Swift.
 - [Swift Developments](https://andybargh.com/swiftdevelopments/) - A weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, WatchOS and AppleTV apps using Swift.
+- [Mobile Developers Cafe](https://mobiledeveloperscafe.com) - A weekly newsletter for Mobile developers with loads of iOS content.
 
 ### Medium
 - [iOS App Development](https://medium.com/ios-os-x-development) - Stories and technical tips about building apps for iOS, Apple Watch, and iPad/iPhone.


### PR DESCRIPTION
Added [Mobile Developers Cafe](https://mobiledeveloperscafe.com) to the list. It's a great newsletter for mobile developers with a stand-alone section for iOS articles, podcasts, dev tutorials, and other content.

## Project URL
https://mobiledeveloperscafe.com

## Category
Newsletter

## Description
Added [Mobile Developers Cafe](https://mobiledeveloperscafe.com) to the list. It's a great newsletter for mobile developers with a stand-alone section for iOS articles, podcasts, dev tutorials, and other content.

## Why it should be included to `awesome-ios` (mandatory)
It's a great newsletter for mobile developers with a stand-alone section for iOS articles, podcasts, dev tutorials, and other content. I think a lot of iOS developers will get benefitted from the curated list of iOS articles sent every week.

## Checklist
It is a newsletter, so I have checked all that applies. 
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
