### PR TITLE
Add Pasteboard 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
     - [XML & HTML](#xml--html)
     - [Other Parsing](#other-parsing)
 - [Passbook](#passbook)
+- [Pasteboard](#pasteboard)
 - [Payments](#payments)
 - [Permissions](#permissions)
 - [Products](#products)
@@ -1477,6 +1478,9 @@ Most of these are paid services, some have free tiers.
 - [passbook](https://github.com/frozon/passbook) - Passbook gem let's you create pkpass for passbook iOS 6+.
 - [Dubai](https://github.com/nomad/dubai) - Generate and Preview Passbook Passes.
 - [Passkit](https://passkit.com) - Design, Create and validate Passbook Passes.
+
+## Pasteboard
+- [Pasteboard](https://github.com/jacobjiangwei/Pasteboard) - Read/Write complicated UIPasteboard data structure including web archive, images, pdf and share image/texts.
 
 ## Payments
 - [Caishen](https://github.com/prolificinteractive/Caishen) - A Payment Card UI & Validator for iOS.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
An easy way to read iOS UIPasteboard including web archive, images, pdf and share image/texts.
## Project URL
<!--- The project URL -->
https://github.com/jacobjiangwei/Pasteboard
## Category
<!--- Category in AwesomeiOS where the project will be added -->
- [Pasteboard](#pasteboard)
## Description
<!--- Describe your changes in detail -->
It's a new library handles read/write complicated data structure in pasteboard, could be anything, so this library simplify the job and easy to read/write.
## Why it should be included to `awesome-ios` (mandatory)
There is no one providing this functionality and we found it necessary, especially when we compare slack, microsoft team, they support in different way and not fully coroperated with iOS ecosystem. So we made it.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [] Has a commit from less than 2 years ago
- [x ] Has a **clear** README in English
