### PR TITLE
Add Screenplay to Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3100,6 +3100,7 @@ Most of these are paid services, some have free tiers.
 - [ScreenshotFramer](https://github.com/IdeasOnCanvas/ScreenshotFramer) - With Screenshot Framer you can easily create nice-looking and localized App Store Images.
 - [Semaphore](https://semaphoreci.com/product/ios) - CI/CD service which makes it easy to build, test and deploy applications for any Apple device. iOS support is fully integrated in Semaphore 2.0, so you can use the same powerful CI/CD pipeline features for iOS as you do for Linux-based development.
 - [Appcircle.io](https://appcircle.io) — Automated mobile CI/CD/CT for iOS with online device simulators
+- [Screenplay](https://screenplay.dev) - Instant rollbacks and canary deployments for iOS.
 
 
 ## App Store


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://screenplay.dev

## Category
Deployment / Distribution

## Description
Instant rollbacks and canary deployments for iOS.

## Why it should be included to `awesome-ios` (mandatory)

_If I'm missing any info, please let me know, I'm a long time lurker of this list but this is my first time submitting :)_ 

Developing for iOS involves thorough manual testing and stressful hotfixes. This is because once a bug or security vulnerability is released, you can't roll it back. Rather, you need to scramble to create a fix, submit to apple, and wait for users to update.

Screenplay up levels iOS deployments by adding a new target to your Xcode project which bundles multiple versions of your app together behind a feature flag. The performant flag allows you to gradually roll out new updates to segments of users and instantly rollback if any issues occur. 

Servers and web development have had rollbacks for years, we're excited to finally see iOS adopting similar practices. Large apps are already using feature flag based rollbacks, and I'm excited to add Screenplay to Awesome iOS so other developers can benefit.

Screenplay is developed fulltime by an ex Airbnb engineer and an ex Facebook engineer. Everyone is welcome to try and offer feedback. Please let me know if you have any questions! - gregorymfoster@gmail.com

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
