### PR TITLE
Add SyntaxHighlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1803,6 +1803,7 @@ Most of these are paid services, some have free tiers.
 - [Croc](https://github.com/jkalash/croc) - A lightweight Swift library for Emoji parsing and querying.
 - [PostalCodeValidator](https://github.com/FormatterKit/PostalCodeValidator) - A validator for postal codes with support for 200+ regions.
 - [CodeMirror Swift](https://github.com/ProxymanApp/CodeMirror-Swift) - A lightweight wrapper of CodeMirror for macOS and iOS. Support Syntax Highlighting & Themes. 
+- [SyntaxHighlight](https://github.com/maoyama/SyntaxHighlight) - TextMate-style syntax highlighting for SwiftUI.
 
 ### Font
 - [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app.


### PR DESCRIPTION
## Project URL
https://github.com/maoyama/SyntaxHighlight

## Category
Text

## Description
SyntaxHighlight makes TextMate-style syntax highlighting easy for SwiftUI.

## Why it should be included to `awesome-ios` (mandatory)
Because syntax highlighting for Swift UI is novel.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [ ] Only one project/change is in this pull request
- [ ] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
