### PR TITLE
Add AttributedStringBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1802,7 +1802,8 @@ Most of these are paid services, some have free tiers.
 - [EFMarkdown](https://github.com/EFPrefix/EFMarkdown) - A lightweight Markdown library for iOS.
 - [Croc](https://github.com/jkalash/croc) - A lightweight Swift library for Emoji parsing and querying.
 - [PostalCodeValidator](https://github.com/FormatterKit/PostalCodeValidator) - A validator for postal codes with support for 200+ regions.
-- [CodeMirror Swift](https://github.com/ProxymanApp/CodeMirror-Swift) - A lightweight wrapper of CodeMirror for macOS and iOS. Support Syntax Highlighting & Themes. 
+- [CodeMirror Swift](https://github.com/ProxymanApp/CodeMirror-Swift) - A lightweight wrapper of CodeMirror for macOS and iOS. Support Syntax Highlighting & Themes.
+- [AttributedStringBuilder](https://github.com/kkiermasz/AttributedStringBuilder) - Makes composing NSAttributedString pleasant by expressing each component within a closure.
 
 ### Font
 - [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app.


### PR DESCRIPTION
Added AttributedStringBuilder to the "Text" group. It is a simple builder that makes composing NSAttributedString pleasant by expressing each component within a closure.

## Project URL
https://github.com/kkiermasz/AttributedStringBuilder

## Category
Text

## Description
Added AttributedStringBuilder to the "Text" group. It is a simple builder that makes composing NSAttributedString pleasant by expressing each component within a closure.

## Why it should be included to `awesome-ios` (mandatory)
I suppose that this is the only library that provides this way of creating attributed string at the moment. It is achieved by using new Swift 5.3 function builder.

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
