### PR TITLE
Add DropdownTransition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2156,6 +2156,7 @@ Most of these are paid services, some have free tiers.
 - [LiquidTransition](https://github.com/AlexandrGraschenkov/LiquidTransition) - removes boilerplate code to perform transition, allows backward animations, custom properties animation and much more!
 - [SPStorkController](https://github.com/IvanVorobei/SPStorkController) - Very similar to the controllers displayed in Apple Music, Podcasts and Mail Apple's applications.
 - [AppstoreTransition](https://github.com/appssemble/appstore-card-transition) - Simulates the appstore card animation transition.
+- [DropdownTransition](https://github.com/nugmanoff/DropdownTransition) - Simple and elegant Dropdown Transition for presenting controllers from top to bottom.
 
 ### Alert & Action Sheet
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/nugmanoff/DropdownTransition

## Category
- Animation
  - Transition

## Description
Simple and elegant Dropdown Transition for presenting controllers from top to bottom.
This library provides custom modal transition that is implemented using `UIPresentationController` and `UITransitionCoordinator`. 

## Why it should be included to `awesome-ios` (mandatory)
I needed to perform the dropdown transition in the app I was building and I've found many great libraries out there that provide desired functionality. But all of them had one flaw in them: they were NOT implemented as custom transitions, but rather as some view animations.
It provides you with greater flexibility and is more suitable for the use in projects that follow some standard architecture & navigation patterns (e.g. Router, Navigator & Coordinator patterns)

## Checklist
- [ ] Has 50 GitHub stargazers or more (42 stars right now)
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor (it's my personal project and it's 1.0.0 version :)
- [ ] Has unit tests, integration tests or UI tests (there is really no feasible way to test custom `UIViewController` transitions, project is mostly UI-related, and no UI testing option is available in this case)
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
