### PR TITLE
Add Atlantis Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@
 - [MTHawkeye](https://github.com/meitu/MTHawkeye) - Profiling / Debugging assist tools for iOS, include tools: UITimeProfiler, Memory Allocations, Living ObjC Objects Sniffer, Network Transaction Waterfall, etc.
 - [Playbook](https://github.com/playbook-ui/playbook-ios) - A library for isolated developing UI components and automatically snapshots of them.
 - [DoraemonKit](https://github.com/didi/DoraemonKit) - A full-featured iOS App development assistant，30+ tools included. You deserve it. 
+- [Atlantis](https://github.com/ProxymanApp/atlantis) - A little and powerful iOS framework for intercepting HTTP/HTTPS Traffic from your iOS app. No more messing around with proxy and certificate config. Inspect Traffic Log with Proxyman app.
 
 ## EventBus
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/ProxymanApp/atlantis

## Category
Debugging

## Description
A little and powerful iOS framework for intercepting HTTP/HTTPS Traffic from your app. No more messing around with proxy, certificate config.

 - Automatically intercept all HTTP/HTTPS Traffic with ease
 - ✅ No need to config HTTP Proxy, Install or Trust any Certificate
 - Support iOS Physical Devices and Simulators
 - Review traffic log from Proxyman
 - Categorize the log by project and devices.
 - Only for Traffic Inspector, not for Debugging Tools
 - Ready for Production

## Why it should be included to `awesome-ios` (mandatory)
It's a nicer way to inspect HTTP Traffic from your iOS devices on the Proxyman app (a native macOS app). No worry about HTTP Config or install any certificates. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
