### PR TITLE
Add attranslate to Localization - Improve support for "polyglot architectures"

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@
 - [LocalizedView](https://github.com/darkcl/LocalizedView) - Setting up application specific localized string within Xib file.
 - [transai](https://github.com/Jintin/transai) - command line tool help you manage localization string files.
 - [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
+- [attranslate](https://github.com/fkirc/attranslate) - Semi-automatically translate or synchronize .strings files or crossplatform-files from different languages.
 - [IBLocalizable](https://github.com/PiXeL16/IBLocalizable) - Localize your views directly in Interface Builder with IBLocalizable.
 - [nslocalizer](https://github.com/samdmarshall/nslocalizer) - A tool for finding missing and unused NSLocalizedStrings.
 - [L10n-swift](https://github.com/Decybel07/L10n-swift) - Localization of an application with ability to change language "on the fly" and support for plural forms in any language.

--- a/README.md
+++ b/README.md
@@ -962,12 +962,12 @@
 - [LocalizedView](https://github.com/darkcl/LocalizedView) - Setting up application specific localized string within Xib file.
 - [transai](https://github.com/Jintin/transai) - command line tool help you manage localization string files.
 - [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
-- [attranslate](https://github.com/fkirc/attranslate) - Semi-automatically translate or synchronize .strings files or crossplatform-files from different languages.
 - [IBLocalizable](https://github.com/PiXeL16/IBLocalizable) - Localize your views directly in Interface Builder with IBLocalizable.
 - [nslocalizer](https://github.com/samdmarshall/nslocalizer) - A tool for finding missing and unused NSLocalizedStrings.
 - [L10n-swift](https://github.com/Decybel07/L10n-swift) - Localization of an application with ability to change language "on the fly" and support for plural forms in any language.
 - [Localize](https://github.com/andresilvagomez/Localize) - Easy tool to localize apps using JSON or Strings and of course IBDesignables with extensions for UI components.
 - [CrowdinSDK](https://github.com/crowdin/mobile-sdk-ios) - Crowdin iOS SDK delivers all new translations from Crowdin project to the application immediately.
+- [attranslate](https://github.com/fkirc/attranslate) - Semi-automatically translate or synchronize .strings files or crossplatform-files from different languages.
 
 ## Logging
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://github.com/fkirc/attranslate

## Category

Localization

## Description

`attranslate` is a semi-automated tool for synchronizing or translating translation-files.

## Why it should be included to `awesome-ios` (mandatory)

https://github.com/metasmile/strsync is already in this list and does something similar to `attranslate`.
However, `attranslate` provides much more flexibility than `strsync`.
Although `strsync` still works fine for many projects, there are many projects where `strsync` does not work.
In particular, this applies to so-called "polyglot architectures".
A "polyglot architecture" is an architecture that is not just a traditional iOS-app, but also includes technologies like React-Native, CapacitorJS, Flutter or any other frameworks.
For those Polyglot-architectures, a tool that only works with `.strings`-files is not sufficient, which is why I wrote `attranslate`.
Moreover, even for traditional architectures, it is nice to have a tool that converts between Android- and iOS-translation in any direction, which was another reason for writing `attranslate`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
