### PR TITLE
Pilgrim - AppsQuickly successor to Typhoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3074,7 +3074,8 @@ Most of these are paid services, some have free tiers.
 - [Reliant](https://github.com/appfoundry/Reliant) - Nonintrusive Objective-C dependency injection.
 - [Kraken](https://github.com/sabirvirtuoso/Kraken) - A Dependency Injection Container for Swift with easy-to-use syntax.
 - [Cleanse](https://github.com/square/Cleanse) - Lightweight Swift Dependency Injection Framework by Square.
-- [Typhoon](https://github.com/appsquickly/Typhoon) - Powerful dependency injection (Objective-C & Swift).
+- [Typhoon](https://github.com/appsquickly/Typhoon) - Powerful dependency injection for Objective-C.
+- [Pilgrim](https://github.com/appsquickly/pilgrim) - Powerful dependency injection Swift (successor to Typhoon).
 - [Perform](https://github.com/thoughtbot/Perform) - Easy dependency injection for storyboard segues.
 - [Alchemic](https://github.com/drekka/Alchemic) - Advanced, yet simple to use DI framework for Objective-C.
 - [Guise](https://github.com/prosumma/Guise) - An elegant, flexible, type-safe dependency resolution framework for Swift.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/appsquickly/pilgrim

## Category
Dependency Injection

## Description
This project succeeds Typhoon, which was the defacto standard DI library for Objective-C. Pilgrim is a pure swift DI container - internally it avoids the ObjC runtime, unlike Typhoon, so it is much more pleasing to use with Swift. 

Pilgrim is only a few days old, so has a handful of stars, but Typhoon has ~2700. _(I considered releasing as Typhoon 5.0, but decided on a new repo). 

## Why it should be included to `awesome-ios` (mandatory)

Pilgrim is an excellent DI library for Swift. The author created the standard DI library for Objective-C. This library provides a migration path for Typhoon users onto a pure Swift solution and stands tall as a nice DI approach in its own right. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
