### PR TITLE
Add Xcodes.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3046,6 +3046,7 @@ Most of these are paid services, some have free tiers.
 - [SkrybaMD](https://github.com/robertherdzik/SkrybaMD) - Markdown Documentation generator. If your team needs an easy way to maintain and create documentation, this generator is for you.
 - [Storyboard -> SwiftUI Converter](https://swiftify.com/#/converter/storyboard2swiftui/) - Storyboard -> SwiftUI Converter is a converter to convert .storyboard and .xib to SwiftUI.
 - [Swift Package Index](https://swiftpackageindex.com) - Swift packages list with many information about quality and compatiblity of package.
+- [Xcodes.app](https://github.com/RobotsAndPencils/XcodesApp) - The easiest way to install and switch between multiple versions of Xcode.
 
 ## Rapid Development
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://github.com/RobotsAndPencils/XcodesApp

## Category

Tools

## Description

Adds Xcodes.app to the tools category

## Why it should be included to `awesome-ios` (mandatory)

I think it's really useful for anyone that needs more than one Xcode version, has had trouble installing from the Mac App Store, etc.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
