### PR TITLE
Add CalendarApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2296,6 +2296,7 @@ Most of these are paid services, some have free tiers.
 - [ios_calendar](https://github.com/maximbilan/Calendar-iOS)  - It's lightweight and simple control with supporting Locale and CalendarIdentifier. There're samples for iPhone and iPad, and also with using a popover. With supporting Persian calendar
 - [FSCalendar](https://github.com/WenchaoD/FSCalendar) - A fully customizable iOS calendar library, compatible with Objective-C and Swift.
 - [ElegantCalendar](https://github.com/ThasianX/ElegantCalendar) - The elegant full-screen calendar missed in SwiftUI.
+- [CalendarApp](https://github.com/richardtop/CalendarApp) - A sample app similar to iOS Calendar, built with CalendarKit and EventKit.
 
 ### Cards
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/richardtop/CalendarApp

## Category
Calendar

## Description
CalendarApp is a template repository serving as a starting point for experiments with CalendarKit. It's a sample calendar app for iOS built with CalendarKit and EventKit. It displays events stored in the EKEventStore similarly to the default calendar app.


## Why it should be included to `awesome-ios` (mandatory)
It's a very simple calendar app that could be used either as a starting point of exploring CalendarKit, or as a tutorial. Very beginner-friendly, as the whole code is just in a single file and less than 100 lines of code. Yet, it is a fully functional calendar that can display events via EventKit.
## Checklist

- [ ] Has 50 GitHub stargazers or more (It's going to get those soon)
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

