### PR TITLE
Add DIContainer Swift link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3094,6 +3094,7 @@ Most of these are paid services, some have free tiers.
 - [DITranquillity](https://github.com/ivlevAstef/DITranquillity) - Dependency injection framework for iOS applications written in clean Swift.
 - [Needle](https://github.com/uber/needle) — Compile-time safe Swift dependency injection framework with real code.
 - [Locatable](https://github.com/vincent-pradeilles/locatable) - A micro-framework that leverages Property Wrappers to implement the Service Locator pattern.
+- [DIContainer Swift](https://github.com/Tavernari/DIContainer) - An ultra-light framework dependency injection container that use Property Wrappers to inject.
 
 ## Deployment / Distribution
 


### PR DESCRIPTION
DI Container is an ultra-light framework to help developers to handle dependency injection with containers. You also can inject your dependencies using property wrapper `@Injected.`

## Project URL
https://github.com/Tavernari/DIContainer

## Category
Dependency Injection

## Description
Adding new lib on Dependency Injection

## Why it should be included to `awesome-ios` (mandatory)
I think it is another option for developers to manage dependencies. It is a very light and efficient lib. Anyone can use it without a problem.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later - (5.1 or above because of propertyWrapper) 
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
