### PR TITLE
Remove BEMSimpleLineGraph as it is now archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,6 @@
 - [Charts](https://github.com/danielgindi/Charts) - A powerful chart / graph framework, the iOS equivalent to [MPAndroidChart](https://github.com/PhilJay/MPAndroidChart).
 - [PNChart](https://github.com/kevinzhow/PNChart) - A simple and beautiful chart lib used in Piner and CoinsMan for iOS.
 - [XJYChart](https://github.com/JunyiXie/XJYChart) - A Beautiful chart for iOS. Support animation, click, slide, area highlight.
-- [BEMSimpleLineGraph](https://github.com/Boris-Em/BEMSimpleLineGraph) - Elegant Line Graphs for iOS (charting library).
 - [JBChartView](https://github.com/Jawbone/JBChartView) - iOS-based charting library for both line and bar graphs.
 - [XYPieChart](https://github.com/xyfeng/XYPieChart) - A simple and animated Pie Chart for your iOS app.
 - [TEAChart](https://github.com/xhacker/TEAChart) - Simple and intuitive iOS chart library. Contribution graph, clock chart, and bar chart.


### PR DESCRIPTION

## Project URL
https://github.com/Boris-Em/BEMSimpleLineGraph

## Category
Charts

## Description
Remove BEMSimpleLineGraph as it is now archived

## Why it should be included to `awesome-ios` (mandatory)
It shouldn't as it's archived.

