### PR TITLE
Add ARHeadsetKit tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
 - [Classpert - A list of 500 iOS Development courses (free and paid), from top e-learning platforms](https://classpert.com/ios-development) - Complete catalog of courses from Udacity, Pluralsight, Coursera, Edx, Treehouse and Skillshare.
 - [iOS Lead Essentials Program](https://iosacademy.essentialdeveloper.com/p/ios-lead-essentials) - Online program meticulously thought out for iOS developers who want to become world-class senior developers and be part of the highest-paid iOS devs in the world. Focuses on key concepts like Swift, TDD, BDD, DDD, Clean Architecture, Design Patterns, Git, Automation, CI/CD, and Modular Design.
 - [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - Extensive tutorials on a high-level framework for experimenting with AR.
-- 
+
 ## Accessibility
 
  *Frameworks that help to support accessibility features and enable people with disabilities to use your app*

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@
 - [iOS 13 & Swift 5 - The Complete iOS App Development Bootcamp](https://www.udemy.com/course/ios-13-app-development-bootcamp/)
 - [Classpert - A list of 500 iOS Development courses (free and paid), from top e-learning platforms](https://classpert.com/ios-development) - Complete catalog of courses from Udacity, Pluralsight, Coursera, Edx, Treehouse and Skillshare.
 - [iOS Lead Essentials Program](https://iosacademy.essentialdeveloper.com/p/ios-lead-essentials) - Online program meticulously thought out for iOS developers who want to become world-class senior developers and be part of the highest-paid iOS devs in the world. Focuses on key concepts like Swift, TDD, BDD, DDD, Clean Architecture, Design Patterns, Git, Automation, CI/CD, and Modular Design.
-- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - Extensive tutorials on a high-level framework for experimenting with AR.
+- [ARHeadsetKit Tutorials](https://github.com/philipturner/ARHeadsetKit) - Extensive tutorials on a high-level framework for experimenting with AR.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@
 - [iOS 13 & Swift 5 - The Complete iOS App Development Bootcamp](https://www.udemy.com/course/ios-13-app-development-bootcamp/)
 - [Classpert - A list of 500 iOS Development courses (free and paid), from top e-learning platforms](https://classpert.com/ios-development) - Complete catalog of courses from Udacity, Pluralsight, Coursera, Edx, Treehouse and Skillshare.
 - [iOS Lead Essentials Program](https://iosacademy.essentialdeveloper.com/p/ios-lead-essentials) - Online program meticulously thought out for iOS developers who want to become world-class senior developers and be part of the highest-paid iOS devs in the world. Focuses on key concepts like Swift, TDD, BDD, DDD, Clean Architecture, Design Patterns, Git, Automation, CI/CD, and Modular Design.
+- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - Extensive tutorials on a high-level framework for experimenting with AR.
+- 
 ## Accessibility
 
  *Frameworks that help to support accessibility features and enable people with disabilities to use your app*
@@ -295,7 +297,6 @@
 - [Placenote](https://github.com/Placenote/PlacenoteSDK-iOS) - A library that makes ARKit sessions persistent to a location using advanced computer vision.
 - [Poly](https://github.com/piemonte/Poly) - Unofficial Google Poly SDK – search and display 3D models.
 - [ARKit Emperor](https://github.com/kboy-silvergym/ARKit-Emperor) - The Emperor give you the most practical ARKit samples ever.
-- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - High-level framework for experimenting with AR and replicating Microsoft Hololens.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@
 - [iOS 13 & Swift 5 - The Complete iOS App Development Bootcamp](https://www.udemy.com/course/ios-13-app-development-bootcamp/)
 - [Classpert - A list of 500 iOS Development courses (free and paid), from top e-learning platforms](https://classpert.com/ios-development) - Complete catalog of courses from Udacity, Pluralsight, Coursera, Edx, Treehouse and Skillshare.
 - [iOS Lead Essentials Program](https://iosacademy.essentialdeveloper.com/p/ios-lead-essentials) - Online program meticulously thought out for iOS developers who want to become world-class senior developers and be part of the highest-paid iOS devs in the world. Focuses on key concepts like Swift, TDD, BDD, DDD, Clean Architecture, Design Patterns, Git, Automation, CI/CD, and Modular Design.
-- [ARHeadsetKit Tutorials](https://github.com/philipturner/ARHeadsetKit) - Extensive tutorials on a high-level framework for experimenting with AR.
+- [ARHeadsetKit Tutorials](https://github.com/philipturner/ARHeadsetKit) - Interactive guides to a high-level framework for experimenting with AR.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 - [Placenote](https://github.com/Placenote/PlacenoteSDK-iOS) - A library that makes ARKit sessions persistent to a location using advanced computer vision.
 - [Poly](https://github.com/piemonte/Poly) - Unofficial Google Poly SDK – search and display 3D models.
 - [ARKit Emperor](https://github.com/kboy-silvergym/ARKit-Emperor) - The Emperor give you the most practical ARKit samples ever.
+- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - High-level framework for experimenting with AR and replicating Microsoft Hololens.
 
 ## Authentication
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/philipturner/ARHeadsetKit#tutorial-series

## Category
<!--- Category in AwesomeiOS where the project will be added -->
Courses

## Description
<!--- Describe your changes in detail -->
I added tutorials for my open-source framework `ARHeadsetKit` to the `Courses` category.

## Why it should be included to `awesome-ios` (mandatory)
See https://github.com/vsouza/awesome-ios/pull/3064 for the main pull request.

ARHeadsetKit has 6 hours worth of tutorials for learning how to use AR on iOS. They are very similar to Apple's 4-hour long course on SwiftUI. Although ARHeadsetKit is a framework, its tutorials are a stand-alone effort that took weeks to develop.

Using augmented reality and easy-to-follow instructions, they make someone's first introduction to learning iOS engaging and interactive. @tensorush, @garrettsickles and @cody-ferguson had little or no prior iOS experience, yet they took the ARHeadsetKit tutorials and became more familiar with iOS.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [not applicable] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

## Clarification

All other course additions did not cite their number of GitHub stars, and most were not published on GitHub. Therefore, that requirement does not apply to ARHeadsetKit's tutorials.