### PR TITLE
Adding Runway to Deployment/Distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3118,7 +3118,7 @@ Most of these are paid services, some have free tiers.
 - [Appcircle.io](https://appcircle.io) — Automated mobile CI/CD/CT for iOS with online device simulators
 - [Screenplay](https://screenplay.dev) - Instant rollbacks and canary deployments for iOS.
 - [Codemagic](https://codemagic.io) - Build, test and deliver iOS apps 20% faster with Codemagic CI/CD. 
-
+- [Runway](https://runway.team) - Easier mobile releases for teams. Integrates across tools (version control, project management, CI, app stores, crash reporting, etc.) to provide a single source of truth for mobile teams to come together around during release cycles. Equal parts automation and collaboration.
 
 ## App Store
 


### PR DESCRIPTION
## Project URL
https://runway.team

## Category
Deployment/Distribution

## Description
Adding Runway, a devtool for mobile releases.

## Why it should be included to `awesome-ios` (mandatory)
We're a team of former iOS engineers, now building Runway to help our iOS (and Android) compatriots ship releases with less friction. It's an orchestration/integration layer that sits on top of all the tools teams are already using, to create a source of truth and a place for the entire interdisciplinary team to get on the same page during release cycles. The aim is to reduce the context-switching and mental load that release managers/captains/drivers have to deal with, and to help involve more than just the technical team members.

We'd love to connect with more of the iOS world here and to have others try out what we're building!

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
