### PR TITLE
Add ARHeadsetKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 - [Placenote](https://github.com/Placenote/PlacenoteSDK-iOS) - A library that makes ARKit sessions persistent to a location using advanced computer vision.
 - [Poly](https://github.com/piemonte/Poly) - Unofficial Google Poly SDK – search and display 3D models.
 - [ARKit Emperor](https://github.com/kboy-silvergym/ARKit-Emperor) - The Emperor give you the most practical ARKit samples ever.
+- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - High-level framework for using $5 Google Cardboard to replicate Microsoft Hololens.
 
 ## Authentication
 


### PR DESCRIPTION
## Project URL
https://github.com/philipturner/ARHeadsetKit
## Description

I added my open-source framework `ARHeadsetKit` to the `ARKit` category.

## Category
ARKit

## Why is should be included to `awesome-ios` (mandatory)

Right now, beginner iOS developers have a massive barrier to working with AR. To make a truly useful app, they have to learn all the intrinsics of ARKit and SceneKit. Or, they must use Xcode templates and sample projects rigged with outdated stuff like Objective-C and Storyboards. ARHeadsetKit has changed that dynamic, but as a side effect of its actual goal.

ARHeadsetKit's primary goal is to tell the public that affordable AR headset experiences exist now, and you don't have to wait years for Apple Glasses or pay thousands of dollars for Microsoft Hololens. In addition, it is a uniquely high-level library for prototyping handheld AR experiences. It also provides useful utilities such as [`MTLLayeredBuffer`](https://github.com/philipturner/ARHeadsetKit/blob/main/docs/articles/layered-buffer.md) and can be used outside of AR. ARHeadsetKit's usability enhancements to some of Apple's low-level frameworks can even run on macOS.

If you are still unsure about whether ARHeadsetKit is relevant to `awesome-ios`, please check out [this article](https://philipturner.github.io/first-affordable-ar-headset).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English