### PR TITLE
Add BottomSheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2246,6 +2246,7 @@ Most of these are paid services, some have free tiers.
 - [Loaf](https://github.com/schmidyy/Loaf) - A simple framework for easy iOS Toasts.
 - [SPAlert](https://github.com/IvanVorobei/SPAlert) - Native popup from Apple Music & Feedback in AppStore. Contains Done & Heart presets.
 - [CleanyModal](https://github.com/loryhuz/CleanyModal) - Use nice customized alerts and action sheets with ease, API is similar to native UIAlertController.
+- [BottomSheet](https://github.com/joomcode/BottomSheet) - Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.
 
 ### Badge
 - [MIBadgeButton](https://github.com/mustafaibrahim989/MIBadgeButton-Swift) - Notification badge for UIButtons.


### PR DESCRIPTION
## Project URL
http://github.com/joomcode/BottomSheet

## Category
UI > Alert & Action Sheet

## Description
Powerful Bottom Sheet component with content based size, interactive dismissal and navigation controller support.

## Why it should be included to `awesome-ios` (mandatory)
Though Apple introduced [a native bottom sheet](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller), it only works on iOS 15 and above, making it practically impossible to use now, so developers need to implement their own.

Besides standard features such as an adaptation to content size and interactive dismissal, this component also seamlessly handles scrollable content and UINavigationController without losing any transitions (including interactive ones).

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
