### PR TITLE
Adds Get, a very nice library that works well with Pulse, PulsePro, and CreateAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,7 @@ Also see [push notifications](#push-notifications)
 - [ThunderRequest](https://github.com/3sidedcube/ThunderRequest) - A simple URLSession wrapper with a generic protocol based request body approach and easy deserialisation of responses.
 - [ReactiveAPI](https://github.com/sky-uk/ReactiveAPI) - Write clean, concise and declarative network code relying on URLSession, with the power of RxSwift. Inspired by Retrofit.
 - [Squid](https://github.com/borchero/Squid) - Declarative and reactive networking framework based on Combine and providing means for HTTP requests, transparent pagination, and WebSocket communication.
+- [Get](https://github.com/kean/Get) - A modern Swift web API client built using async/await.
 
 ### Email
 


### PR DESCRIPTION
## Project URL
https://github.com/kean/Get

## Category
Networking

## Description
Get is a fantastic networking library.

## Why it should be included to `awesome-ios` (mandatory)
Get was created by the same person who created Nuke, likely the most popular 3rd party asynchronous image library in use by iOS developers. There is a nice blog post outlining its creation here: https://kean.blog/post/new-api-client Get also works well in tandem with the creator's other awesome libraries and tools: CreateAPI, Pulse, and PulsePro.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
