### PR TITLE
Adds Pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,7 @@
 - [Spy](https://github.com/appunite/Spy) - Lightweight, flexible, multiplatform (iOS, macOS, tvOS, watchOS, Linux) logging utility written in pure Swift that allows you to log on different levels and channels which you can define on your own depending on your needs.
 - [Diagnostics](https://github.com/WeTransfer/Diagnostics) - Allow users to easily share Diagnostics with your support team to improve the flow of fixing bugs.
 - [Gedatsu](https://github.com/bannzai/gedatsu) - Provide readable format about AutoLayout error console log.
+- [Pulse](https://github.com/kean/Pulse) - Pulse is a powerful logging system for Apple Platforms. Native. Built with SwiftUI.
 
 ## Machine Learning
 


### PR DESCRIPTION
## Project URL
https://github.com/kean/Pulse

## Category
Logging

## Description
I took the description from the Pulse README.

## Why it should be included to `awesome-ios` (mandatory)
Pulse is a fantastic library, especially when you use its out-of-the-box UI framework to display your logs, and _even more especially_ when you integrate your networking library to show network requests and responses. This is probably easiest with Get, one of the author's other libraries, but possible with any native networking library. PulsePro (a separate open source MacOS app) makes viewing logs off the device (on the same network) even easier.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
