### PR TITLE
Adds CreateAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,6 +1485,7 @@ Most of these are paid services, some have free tiers.
 - [AcknowledgementsPlist](https://github.com/cats-oss/AcknowledgementsPlist) - AcknowledgementsPlist manages the licenses of libraries that depend on your iOS app.
 - [CoreXLSX](https://github.com/MaxDesiatov/CoreXLSX) - Excel spreadsheet (XLSX) format support in pure Swift.
 - [SVGView](https://github.com/exyte/SVGView) - SVG parser and renderer written in SwiftUI.
+- [CreateAPI](https://github.com/CreateAPI/CreateAPI) - Delightful code generation for OpenAPI specs for Swift written in Swift.
 
 
 ## Passbook


### PR DESCRIPTION
## Project URL
https://github.com/CreateAPI/CreateAPI

## Category
Parsing -> Other Parsing
I almost put this in networking, but decided on the above instead. It's the only result if you search this doc for OpenAPI, so I figure the right folks will probably find it.

## Description
I took the description from the CreateAPI README.

## Why it should be included to `awesome-ios` (mandatory)
OpenAPI is now the de facto standard for describing backend networking APIs. CreateAPI parses an OpenAPI document and spits out Swift objects that you can include in your project. It'll even create a separate swift package for you, if you want it to do that. It's an amazing tool.

## Checklist
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
