### PR TITLE
Fix Facebook's Design URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3268,7 +3268,7 @@ Most of these are paid services, some have free tiers.
 ### iOS UI Template
 - [iOS UI Design Kit](https://www.invisionapp.com/inside-design/design-resources/tethr/)
 - [iOS Design Guidelines](https://ivomynttinen.com/blog/ios-design-guidelines)
-- [iOS GUI by Facebook Design Resources](https://facebook.design/)
+- [iOS GUI by Facebook Design Resources](https://design.facebook.com/toolsandresources/ios-11-iphone-gui/)
 
 ### Prototyping
 - [FluidUI](https://www.fluidui.com)

--- a/README.md
+++ b/README.md
@@ -3268,7 +3268,7 @@ Most of these are paid services, some have free tiers.
 ### iOS UI Template
 - [iOS UI Design Kit](https://www.invisionapp.com/inside-design/design-resources/tethr/)
 - [iOS Design Guidelines](https://ivomynttinen.com/blog/ios-design-guidelines)
-- [iOS GUI by Facebook Design Resources](https://design.facebook.com/toolsandresources/ios-11-iphone-gui/)
+- [iOS 11 iPhone GUI from Design at Meta](https://design.facebook.com/toolsandresources/ios-11-iphone-gui/)
 
 ### Prototyping
 - [FluidUI](https://www.fluidui.com)


### PR DESCRIPTION
## Project URL
https://design.facebook.com/toolsandresources/ios-11-iphone-gui/

## Category
[iOS UI Template](https://github.com/vsouza/awesome-ios#ios-ui-template)

## Description
Changed domain to avoid redirection (`facebook.design` → `design.facebook.com`), and directly link to iOS 11 kit
(**Please note:** iOS 11 is 5 years old in 2022, but the kit was last updated by Facebook's Design Team in May 2022)

## Why it should be included to `awesome-ios`
Already listed; updated information

## Checklist

| Task | Completed? | Comments
|--|--|--|
| Has 50 GitHub stargazers or more | **N/A** | Not on Github
| Only one project/change is in this pull request | **Yes** |
| Isn't an archived project | **No** | Last updated in May 2022 and is still listed on website
| Has more than one contributor | **Yes** | Currently has 28 contributors
| Has unit tests, integration tests or UI tests | **N/A** | Not on Github
| Addition in chronological order (bottom of category) | **No** | Already listed; updated information
| Supports iOS 9 / tvOS 10 or later | **Yes** | Designed after iOS 11
| Supports Swift 4 or later | **N/A** | Not a coding project
| Has a commit from less than 2 years ago | **Yes** | Last updated in May 2022
| Has a **clear** README in English | **Yes** |
