### PR TITLE
Adds IndieWatch Newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3289,6 +3289,7 @@ Most of these are paid services, some have free tiers.
 - [iOS Cookies Newsletter](https://us11.campaign-archive.com/home/?u=cd1f3ed33c6527331d82107ba&id=532dc7fb64) - A weekly digest of new iOS libraries written in Swift.
 - [Swift Developments](https://andybargh.com/swiftdevelopments/) - A weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, WatchOS and AppleTV apps using Swift.
 - [Mobile Developers Cafe](https://mobiledeveloperscafe.com) - A weekly newsletter for Mobile developers with loads of iOS content.
+- [Indie Watch](https://indie.watch/) - A weekly newsletter featuring the best apps made by indie iOS developers.
 
 ### Medium
 - [iOS App Development](https://medium.com/ios-os-x-development) - Stories and technical tips about building apps for iOS, Apple Watch, and iPad/iPhone.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds Indie Watch Newsletter (http://indie.watch/) to the Newsletter section of the document. 

## Project URL
https://indie.watch/

## Category
Newsletter

## Description
Indie Watch is an exclusive weekly hand-curated newsletter showcasing the best iOS apps from developers worldwide.

## Why it should be included to `awesome-ios` (mandatory)
I believe that this newsletter not only helps inspire other iOS developers but also helps them come up with app ideas. 

Additionally, it helps foster a community of indie iOS developers that are happy and willing to share their stories and advice with others. More importantly, though, I think it helps level the marketing playing field for indie iOS developers by giving them a chance to meaningfully share their stories, their apps, and their passion projects without the need for marketing know-how or a marketing budget. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Has 50 GitHub stargazers or more
- [ ] Only one project/change is in this pull request
- [ ] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [X] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 4 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English

**Many of these checkboxes do not apply in my case (newsletter submission).**