### PR TITLE
Safari Extensions Category

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@
     - [React-Like](#react-like)
 - [Reflection](#reflection)
 - [Regex](#regex)
+- [Safari](#safari)
+    - [Extensions](#extensions-safari)
 - [SDK](#sdk)
     - [Official](#official)
     - [Unofficial](#unofficial)
@@ -1619,6 +1621,13 @@ Most of these are paid services, some have free tiers.
 - [Regex](https://github.com/crossroadlabs/Regex) - Regular expressions for swift.
 - [Regex](https://github.com/brynbellomy/Regex) - Regex class for Swift. Wraps NSRegularExpression.
 - [sindresorhus/Regex](https://github.com/sindresorhus/Regex) - Swifty regular expressions, fully tested & documented, and with correct Unicode handling.
+
+## Safari
+
+### Extensions
+
+- [AdGuard](https://github.com/AdguardTeam/AdGuardForSafari) - Free and open source, highly customizable and lightning fast ad blocking extension.
+- [Parrotflow](https://github.com/jsj/parrotflow) - An open source extension that enhances search engines with ChatGPT
 
 ## SDK
 


### PR DESCRIPTION
**Your Project**: Parrotflow  
**Project URL**: https://github.com/jsj/parrotflow
**Category**: _Safari Extension_  
**Description**: _Adds Ability to Pipe Google Query to ChatGPT_

Inclusion requirements:
- [ ] Has 50 GitHub stargazers or more
- [ ] Only one project/change is in this pull request
- [X] Isn't an archived project
- [ ] Has more than one contributor
- [X] Has unit tests, integration tests or UI tests
- [X] Addition in alphabetical order (bottom of category)
- [X] Supports iOS 12 / tvOS 10 or later
- [X] Supports Swift 4 or later
- [X] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
 
This commit creates a **_new_** category for Safari extensions. Safari extensions are confusing because they lack traditional documentation examples found in other APIs. This commits creates the category and populates it with two open source examples.
