### PR TITLE
Remove puree as the repo has been archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,7 +1003,6 @@
 - [SwiftyTextTable](https://github.com/scottrhoyt/SwiftyTextTable) - A lightweight tool for generating text tables.
 - [Watchdog](https://github.com/wojteklu/Watchdog) - Class for logging excessive blocking on the main thread.
 - [XCGLogger](https://github.com/DaveWoodCom/XCGLogger) - A debug log framework for use in Swift projects. Allows you to log details to the console (and optionally a file), just like you would have with NSLog or println, but with additional information, such as the date, function name, filename and line number.
-- [puree](https://github.com/cookpad/puree-ios) - A log collector for iOS.
 - [Colors](https://github.com/icodeforlove/Colors) - A pure Swift library for using ANSI codes. Basically makes command-line coloring and styling very easy!
 - [Loggerithm](https://github.com/honghaoz/Loggerithm) - A lightweight Swift logger, uses `print` in development and `NSLog` in production. Support colourful and formatted output.
 - [AELog](https://github.com/tadija/AELog) - Simple, lightweight and flexible debug logging framework written in Swift.


### PR DESCRIPTION
https://github.com/cookpad/puree-ios

> "Puree" is no longer supported. Check out new version "Puree-Swift" https://github.com/cookpad/Puree-Swift

