### PR TITLE
Add AztecEditor-iOS to Text category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1844,6 +1844,7 @@ Most of these are paid services, some have free tiers.
 - [PostalCodeValidator](https://github.com/FormatterKit/PostalCodeValidator) - A validator for postal codes with support for 200+ regions.
 - [CodeMirror Swift](https://github.com/ProxymanApp/CodeMirror-Swift) - A lightweight wrapper of CodeMirror for macOS and iOS. Support Syntax Highlighting & Themes.
 - [TwitterTextEditor](https://github.com/twitter/TwitterTextEditor) - A standalone, flexible API that provides a full featured rich text editor for iOS applications.
+- [AztecEditor-iOS](https://github.com/wordpress-mobile/AztecEditor-iOS) - Aztec is a Swift library that provides a `UITextView` subclass with HTML visual-editing capabilities. The plugin API supports customization HTML conversion from/to HTML for compatibility with your needs.
 
 ### Font
 - [FontBlaster](https://github.com/ArtSabintsev/FontBlaster) - Programmatically load custom fonts into your iOS app.


### PR DESCRIPTION
Thanks for your contribution! This is a template that can make it easier when submitting your contribution:

**Your Project**: _AztecEditor-iOS_  
**Project URL**: _https://github.com/wordpress-mobile/AztecEditor-iOS_  
**Category**: _Text_  
**Description**: A very straightforward UITextView subclass and a robust conversion system for transforming HTML to NSAttributedString and back. It also has an amazing example application for showing off all of the capabilities.

Inclusion requirements:
- [x] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [x] Has more than one contributor
- [x] Has unit tests, integration tests or UI tests
- [x] Addition in alphabetical order (bottom of category)
- [x] Supports iOS 12 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
 
:heart: Awesome iOS Contributors
