### PR TITLE
Add lrm - Localization Resource Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [Localize-Swift](https://github.com/marmelroy/Localize-Swift) - Swift 2.0 friendly localization and i18n with in-app language switching.
 - [LocalizedView](https://github.com/darkcl/LocalizedView) - Setting up application specific localized string within Xib file.
 - [transai](https://github.com/Jintin/transai) - command line tool help you manage localization string files.
+- [lrm](https://github.com/nickprotop/LocalizationManager) - CLI tool for managing iOS .strings and .stringsdict files with validation, machine translation (Ollama, Google, DeepL), and code scanning.
 - [Strsync](https://github.com/metasmile/strsync) - Automatically translate and synchronize .strings files from base language.
 - [IBLocalizable](https://github.com/PiXeL16/IBLocalizable) - Localize your views directly in Interface Builder with IBLocalizable.
 - [nslocalizer](https://github.com/samdmarshall/nslocalizer) - A tool for finding missing and unused NSLocalizedStrings.


### PR DESCRIPTION
## Description

Adding [lrm](https://github.com/nickprotop/LocalizationManager) (Localization Resource Manager) to the Localization section.

## Features for iOS Development

- Full support for iOS `.strings` and `.stringsdict` files
- Handles `{lang}.lproj/Localizable.strings` folder structure
- Validates localization files for missing translations, duplicates, empty values
- Machine translation using local LLMs (Ollama) or cloud providers (Google, DeepL, Azure)
- Interactive Terminal UI for visual editing
- Export/import to CSV for translators
- CI/CD automation with JSON output

Similar to existing entries like `transai`, `locheck`, and `BartyCrouch`, but with additional features like LLM-powered translation.