### PR TITLE
Add off-grid-mobile: on-device LLM + vision + image gen (React Native, iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [DL4S](https://github.com/palle-k/DL4S) - Deep Learning for Swift: Accelerated tensor operations and dynamic neural networks based on reverse mode automatic differentiation for every device that can run Swift.
 - [SwiftCoreMLTools](https://github.com/JacopoMangiavacchi/SwiftCoreMLTools) - A Swift library for creating and exporting CoreML Models in Swift.
 - [iOS-GenAI-Sampler](https://github.com/shu223/iOS-GenAI-Sampler) - A collection of Generative AI examples on iOS.
+- [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile) - Run LLMs, vision models, and Stable Diffusion fully on-device. No internet, no data leaves the phone. React Native, supports iOS and Android. MIT license.
 
 **[back to top](#contributing-and-collaborating)**
 


### PR DESCRIPTION
## What

Adds [off-grid-mobile](https://github.com/alichherawalla/off-grid-mobile) to the **Machine Learning** section.

## About the project

off-grid-mobile is an open source React Native app (MIT) that runs LLMs, vision models, and Stable Diffusion fully on-device on iOS (and Android). Uses Core ML for image generation on iOS.

- On-device LLM inference (llama.cpp via llm.rn)
- On-device vision/multimodal models
- On-device text-to-image via Core ML / Stable Diffusion Swift
- No internet, no accounts, no data leaves the device
- MIT license, actively maintained

Good real-world example of production Core ML + llama.cpp integration in a React Native iOS app.