### PR TITLE
Add BookShelves - EPUB reader for macOS/iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 **[back to top](#contributing-and-collaborating)**
 
 ### PDF
+- [BookShelves](https://getbookshelves.app) - EPUB reader for macOS and iOS with free public domain book discovery, OPDS support, and CloudKit sync.
 - [FastPdfKit](https://github.com/mobfarm/FastPdfKit) - A Static Library to be embedded on iOS applications to display pdf documents derived from Fast PDF.
 - [FolioReaderKit](https://github.com/FolioReader/FolioReaderKit) - A Swift ePub reader and parser framework for iOS.
 - [PDFGenerator](https://github.com/sgr-ksmt/PDFGenerator) - A simple Generator of PDF in Swift. Generate PDF from view(s) or image(s).


### PR DESCRIPTION
**Your Project**: _BookShelves_
**Project URL**: _https://getbookshelves.app_
**Category**: _Media > PDF_
**Description**: _EPUB reader for macOS and iOS with free public domain book discovery, OPDS support, and CloudKit sync._

BookShelves is a native Swift EPUB reader available on both macOS and iOS. It features:
- WebView-based EPUB rendering with pagination
- Free public domain book discovery (Standard Ebooks, Internet Archive, OAPEN)
- OPDS catalog support
- CloudKit sync across devices
- CloudFront-signed S3 access for book content

Placed in the PDF section alongside FolioReaderKit (the existing ePub entry), in alphabetical order.