### PR TITLE
add: Swift Student Challenge Resources to Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [iOS & Swift - The Complete iOS App Development Bootcamp](https://www.udemy.com/course/ios-13-app-development-bootcamp/)
 - [Ray Wenderlich](https://www.raywenderlich.com/2690-learn-to-code-ios-apps-1-welcome-to-programming) - Learn to code iOS Apps.
 - [Stanford - Developing apps for iOS](https://cs193p.stanford.edu/) - Stanford's CS193p - Developing Apps for iOS.
+- [Swift Student Challenge Resources](https://github.com/alyboii/swift-student-challenge-resources) - A curated resource library for Apple's Swift Student Challenge — tutorials, WWDC sessions, storytelling guides, and winner insights.
 - [Udacity - Intro to iOS App Development with Swift](https://www.udacity.com/course/intro-to-ios-app-development-with-swift--ud585) - Udacity free course. Make Your First iPhone App.
 
 **[back to top](#contributing-and-collaborating)**


### PR DESCRIPTION
## Description

Adds [Swift Student Challenge Resources](https://github.com/alyboii/swift-student-challenge-resources) to the Getting Started → Courses section.

A curated, community-maintained resource library for students preparing for Apple's Swift Student Challenge. Covers SwiftUI, UIKit, concurrency, networking, persistence, testing, accessibility, and submission storytelling — vetted links organized by topic and difficulty level (B/I/A).

## Checklist

- [x] Link is live and publicly accessible
- [x] Follows the existing entry format
- [x] Alphabetically sorted (after "Stanford", before "Udacity")
- [x] Resource is freely accessible