### PR TITLE
Add Compress PDF tool – free, browser-based, no uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,6 +1362,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [UIView 2 PDF](https://github.com/RobertAPhillips/UIView_2_PDF) - PDF generator using UIViews or UIViews with an associated XIB.
 
 **[back to top](#contributing-and-collaborating)**
+- [Compress PDF – NoCodeVista](https://nocodevista.com/tools/compress-pdf) - Free browser-based PDF compressor — reduce file size up to 90%, no uploads, 100% private.
 
 ### Streaming
 - [Airstream](https://github.com/qasim/Airstream) - A framework for streaming audio between Apple devices using AirPlay.


### PR DESCRIPTION
Hi! I'd like to suggest adding **[Compress PDF](https://nocodevista.com/tools/compress-pdf)** to this list.

Free browser-based PDF compressor — reduce PDF file size up to 90% without losing quality, no uploads needed.

It's free, privacy-first (runs entirely in the browser — no file uploads), and no sign-up needed. Happy to adjust the placement if there's a better section. Thanks!