### PR TITLE
Add 不拖 (BuTuo) - minimalist iOS task manager app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3272,6 +3272,7 @@ Most of these are paid services, some have free tiers.
  * [DuctTape](https://github.com/marty-suzuki/DuctTape) - KeyPath dynamicMemberLookup based syntax sugar for swift.
  * [ReviewKit](https://github.com/simonmitchell/ReviewKit) - A framework which helps gatekeep review prompt requests – using SKStoreReviewController – to users who have had a good time using your app by logging positive and negative actions.
  * [SwiftBoost](https://github.com/sparrowcode/SwiftBoost) - Collection of Swift-extensions to boost development process.
+ * [不拖 (BuTuo)](https://apps.apple.com/app/id6761042128) - A minimalist iOS task manager that helps you stop procrastinating. Focus on one task at a time to build momentum and get things done.
 
  **[back to top](#contributing-and-collaborating)**
 


### PR DESCRIPTION
## Description

Adding **不拖 (BuTuo)** — a minimalist iOS task manager app designed to help users stop procrastinating.

**App Store:** https://apps.apple.com/app/id6761042128

### Why it belongs here
- Native iOS app built with Swift
- Focused, single-task productivity tool
- Helps users build anti-procrastination habits
- Clean, minimalist design philosophy

---

*Added under the Utility section.*