### PR TITLE
chore: 100 stars is inclusive; add quality-check workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If your project does not meet every **hard rule**, please do not open a PR. We w
 
 A project is only accepted if it meets **every** item in this list:
 
-1. **More than 100 GitHub stargazers.**
+1. **At least 100 GitHub stargazers.**
 2. **More than one contributor**, excluding bots (Dependabot, Renovate, etc.).
 3. **Not archived.** The repository must load on GitHub (no 404, no 451).
 4. **Has an OSI-approved open-source license** — MIT, Apache-2.0, BSD-2/3-Clause, MPL-2.0, ISC, or similar. Source-available licenses (BSL, SSPL, Elastic, Commons Clause) are **not** accepted.
@@ -38,7 +38,7 @@ These aren't hard rejections, but a project that fails several of them is unlike
 
 ## Hidden-gem exception
 
-Projects with **75–100 stars** can still be accepted if the PR body explains why the project is exceptional (novel approach, solves a real ecosystem gap, notable adoption by known apps). This exception still requires:
+Projects with **75–99 stars** can still be accepted if the PR body explains why the project is exceptional (novel approach, solves a real ecosystem gap, notable adoption by known apps). This exception still requires:
 
 - At least 6 months of repository history.
 - More than one contributor.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Thanks for contributing to Awesome iOS! Please fill out this template completely
 
 ## Hard requirements (all must be checked)
 
-- [ ] Repository has **more than 100 GitHub stargazers**.
+- [ ] Repository has **at least 100 GitHub stargazers**.
 - [ ] Has **more than one contributor** (excluding bots).
 - [ ] Is **not archived** and responds on GitHub (no 404 / 451).
 - [ ] Has an **OSI-approved open-source license** (MIT, Apache-2.0, BSD-2/3, MPL-2.0, ISC, …). Source-available (BSL, SSPL, Elastic, Commons Clause) is not accepted.
@@ -41,7 +41,7 @@ Maintainers may ask questions if several of these apply:
 - [ ] No trailing whitespace.
 - [ ] Description ends with a full stop/period.
 
-## Hidden-gem exception (optional — only if 75–100 stars)
+## Hidden-gem exception (optional — only if 75–99 stars)
 
 If your project has fewer than 100 stars but you believe it deserves inclusion, tick this box and add a short justification below (novel approach, ecosystem gap, notable adoption). All other hard rules still apply.
 

--- a/.github/scripts/quality_check.py
+++ b/.github/scripts/quality_check.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Check added GitHub repo entries in a PR against Awesome iOS inclusion rules.
+
+Inputs (via env vars):
+  BASE_SHA         — base commit SHA (target branch)
+  HEAD_SHA         — head commit SHA (PR branch)
+  GH_TOKEN         — GitHub token with `repo` read scope
+  PR_BODY          — full PR body text (used to detect a hidden-gem justification)
+
+Output:
+  Writes a markdown report to `quality-report.md` in the current directory.
+  Exits 0 if all added repos pass the hard rules, 1 otherwise.
+
+Only the HARD rules that are programmatically verifiable are checked here:
+  1. More than 100 stargazers (or ≥75 with a hidden-gem justification in the PR body).
+  2. Commit in the last 24 months (pushed_at).
+  3. More than one contributor (excluding bots).
+  4. Not archived.
+  5. OSI-approved license.
+
+The rest (SPM support, iOS/Swift version floors, paid-product checks, README
+quality, category placement) remain a human-review responsibility.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+MIN_STARS = 100
+HIDDEN_GEM_MIN_STARS = 75
+RECENT_COMMIT_MONTHS = 24
+
+# SPDX identifiers considered OSI-approved and open-source-friendly.
+# Source-available (BSL, SSPL, Elastic, Commons Clause) deliberately not here.
+ACCEPTED_LICENSES = {
+    "mit", "apache-2.0", "bsd-2-clause", "bsd-3-clause", "mpl-2.0", "isc",
+    "unlicense", "cc0-1.0", "0bsd", "wtfpl", "zlib", "artistic-2.0",
+    "lgpl-2.1", "lgpl-3.0", "gpl-2.0", "gpl-3.0", "agpl-3.0", "epl-2.0",
+    "bsd-3-clause-clear", "postgresql", "ncsa",
+}
+
+BOT_PATTERNS = re.compile(r"(\[bot\]|dependabot|renovate|github-actions|greenkeeper)", re.IGNORECASE)
+
+URL_RE = re.compile(r"https://github\.com/([\w.-]+)/([\w.-]+?)(?=[/)\s#?]|$)")
+ENTRY_RE = re.compile(r"^\+-\s+\[([^\]]+)\]\((https?://[^)]+)\)")
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(cmd)}\n{result.stderr}")
+    return result.stdout
+
+
+def added_entries(base_sha: str, head_sha: str) -> list[tuple[str, str, str]]:
+    """Return (entry_name, owner, repo) for each new list entry added to README.md."""
+    diff = run(["git", "diff", "--unified=0", f"{base_sha}..{head_sha}", "--", "README.md"])
+    out = []
+    for line in diff.splitlines():
+        m = ENTRY_RE.match(line)
+        if not m:
+            continue
+        name, url = m.group(1), m.group(2)
+        u = URL_RE.search(url)
+        if not u:
+            continue
+        owner, repo = u.group(1), u.group(2).rstrip("/")
+        if not owner or not repo or repo in (".", ".."):
+            continue
+        out.append((name, owner, repo))
+    return out
+
+
+def check_repo(owner: str, repo: str) -> dict:
+    """Query GitHub API; return a status dict."""
+    try:
+        data = json.loads(run(["gh", "api", f"repos/{owner}/{repo}"]))
+    except RuntimeError as exc:
+        msg = str(exc)
+        if "HTTP 404" in msg or "Not Found" in msg:
+            return {"ok": False, "reason": "404 not found"}
+        if "HTTP 451" in msg:
+            return {"ok": False, "reason": "451 (unavailable for legal reasons)"}
+        return {"ok": False, "reason": f"api error: {msg[:200]}"}
+
+    # Contributor count — first page, anon included. If we see >1 on page 1, we're done.
+    contributors_count = 0
+    try:
+        contribs = json.loads(run([
+            "gh", "api", f"repos/{owner}/{repo}/contributors?per_page=10&anon=1",
+        ]))
+        for c in contribs:
+            login = c.get("login") or c.get("name") or ""
+            if BOT_PATTERNS.search(login):
+                continue
+            contributors_count += 1
+    except RuntimeError:
+        pass  # tolerate — will show as "unknown" in report
+
+    return {
+        "ok": True,
+        "archived": bool(data.get("archived")),
+        "stars": int(data.get("stargazers_count") or 0),
+        "pushed_at": data.get("pushed_at"),
+        "license": ((data.get("license") or {}).get("spdx_id") or "").lower(),
+        "html_url": data.get("html_url"),
+        "contributors": contributors_count,
+    }
+
+
+def evaluate(status: dict, allow_hidden_gem: bool) -> list[tuple[str, str]]:
+    """Return list of (level, message) per check. level is "pass", "warn", or "fail".
+
+    "fail" is a hard-rule violation and blocks the PR.
+    "warn" is a soft-signal violation — shown as a warning, does not block.
+    """
+    results = []
+    if not status["ok"]:
+        results.append(("fail", f"Repository unreachable: {status['reason']}"))
+        return results
+
+    # Archived — hard
+    if status["archived"]:
+        results.append(("fail", "Archived on GitHub"))
+    else:
+        results.append(("pass", "Not archived"))
+
+    # Stars — hard
+    stars = status["stars"]
+    min_stars = HIDDEN_GEM_MIN_STARS if allow_hidden_gem else MIN_STARS
+    gem_note = " — hidden-gem rule in effect" if allow_hidden_gem else ""
+    if stars >= min_stars:
+        results.append(("pass", f"At least {min_stars} stars ({stars} stars{gem_note})"))
+    else:
+        results.append(("fail", f"Only {stars} stars — needs at least {min_stars}{gem_note}"))
+
+    # Recent commit — SOFT signal (warning only, does not block)
+    pushed = status.get("pushed_at")
+    if pushed:
+        try:
+            dt = datetime.fromisoformat(pushed.replace("Z", "+00:00"))
+            cutoff = datetime.now(timezone.utc) - timedelta(days=RECENT_COMMIT_MONTHS * 30)
+            if dt >= cutoff:
+                results.append(("pass", f"Commit in last {RECENT_COMMIT_MONTHS} months (last pushed {pushed[:10]})"))
+            else:
+                results.append(("warn", f"No commit in last {RECENT_COMMIT_MONTHS} months (last pushed {pushed[:10]}) — soft signal, not blocking"))
+        except ValueError:
+            results.append(("warn", "Could not parse last commit date"))
+    else:
+        results.append(("warn", "No last commit date reported"))
+
+    # Contributors — hard
+    contribs = status["contributors"]
+    if contribs > 1:
+        results.append(("pass", f"More than 1 contributor ({contribs} found)"))
+    else:
+        results.append(("fail", f"Only {contribs} contributor(s) found — needs more than 1"))
+
+    # License — hard
+    lic = status["license"]
+    if lic and lic in ACCEPTED_LICENSES:
+        results.append(("pass", f"OSI-approved license ({lic.upper()})"))
+    elif lic:
+        results.append(("fail", f"License `{lic.upper()}` is not in the accepted list"))
+    else:
+        results.append(("fail", "No license detected on the repository"))
+
+    return results
+
+
+def has_hidden_gem_justification(pr_body: str) -> bool:
+    """Detect a ticked hidden-gem checkbox in the PR body."""
+    if not pr_body:
+        return False
+    return bool(re.search(r"^\s*-\s*\[x\]\s+Hidden-gem", pr_body, re.IGNORECASE | re.MULTILINE))
+
+
+def render_report(entries: list[dict]) -> str:
+    if not entries:
+        return ("## ✅ Quality check — no new repositories added\n\n"
+                "No new GitHub repository entries were added in this PR, so the automated "
+                "quality check has nothing to verify. A maintainer will still review manually.\n")
+
+    any_failed = any(not e["overall_pass"] for e in entries)
+    any_warned = any(any(r[0] == "warn" for r in e["results"]) for e in entries)
+    lines = []
+    if any_failed:
+        header = "## ❌ Quality check — failures"
+    elif any_warned:
+        header = "## ✅ Quality check — passed with warnings"
+    else:
+        header = "## ✅ Quality check — all added repos pass the hard rules"
+    lines.append(header)
+    lines.append("")
+    if any_failed:
+        lines.append("One or more repositories added in this PR do not meet the hard inclusion rules. "
+                     "See the breakdown below. Full rules are in "
+                     "[CONTRIBUTING.md](../blob/master/.github/CONTRIBUTING.md).")
+    else:
+        lines.append("Every new repository in this PR passes the **automated** hard rules "
+                     "(stars, contributors, archived, license). A human maintainer "
+                     "will still review the remaining rules (SPM support, version floors, paid-product "
+                     "check, README quality, alphabetical placement)."
+                     + (" ⚠️ warnings below are soft signals and do not block the PR." if any_warned else ""))
+    lines.append("")
+    for e in entries:
+        icon = "✅" if e["overall_pass"] else "❌"
+        lines.append(f"### {icon} [{e['name']}]({e['url']})")
+        lines.append("")
+        for level, msg in e["results"]:
+            bullet = {"pass": "- ✅", "warn": "- ⚠️", "fail": "- ❌"}[level]
+            lines.append(f"{bullet} {msg}")
+        lines.append("")
+    lines.append("---")
+    lines.append("_Automated check. The remaining hard rules — Swift Package Manager support, "
+                 "iOS 14+ / Swift 5.5+ floors, \"not a paid library / app / course\", README quality — "
+                 "are verified by a human reviewer._")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    base = os.environ.get("BASE_SHA")
+    head = os.environ.get("HEAD_SHA")
+    pr_body = os.environ.get("PR_BODY", "")
+    if not base or not head:
+        print("BASE_SHA and HEAD_SHA are required", file=sys.stderr)
+        return 2
+
+    raw_entries = added_entries(base, head)
+    print(f"Found {len(raw_entries)} added repo entries in README.md diff", file=sys.stderr)
+    allow_hidden_gem = has_hidden_gem_justification(pr_body)
+    if allow_hidden_gem:
+        print("Hidden-gem justification detected — star minimum relaxed to 75", file=sys.stderr)
+
+    report_entries = []
+    overall_pass = True
+    for name, owner, repo in raw_entries:
+        status = check_repo(owner, repo)
+        results = evaluate(status, allow_hidden_gem=allow_hidden_gem)
+        # "fail" blocks; "warn" does not.
+        passed = not any(level == "fail" for level, _ in results)
+        if not passed:
+            overall_pass = False
+        report_entries.append({
+            "name": name,
+            "url": f"https://github.com/{owner}/{repo}",
+            "results": results,
+            "overall_pass": passed,
+        })
+
+    Path("quality-report.md").write_text(render_report(report_entries))
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,0 +1,65 @@
+name: PR Quality Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - README.md
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run quality check
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set +e
+          python .github/scripts/quality_check.py
+          echo "script_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: always() && hashFiles('quality-report.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Replace any prior quality-check comment to avoid noise on resubmissions.
+          MARKER="<!-- awesome-ios-quality-check -->"
+          { echo "$MARKER"; cat quality-report.md; } > comment.md
+
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq \
+            "[.[] | select(.body | startswith(\"$MARKER\"))] | .[0].id // empty")
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING_ID" \
+              -f body="$(cat comment.md)"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file comment.md
+          fi
+
+      - name: Fail if any check failed
+        if: steps.check.outputs.script_exit != '0'
+        run: |
+          echo "::error::One or more added repositories failed the automated quality check."
+          exit 1


### PR DESCRIPTION
## Summary

Two follow-ups on top of #3306:

1. **Star rule is inclusive** — change "more than 100 stargazers" to "at least 100 stargazers" in `CONTRIBUTING.md` and the PR template. The intent of the bar is "100 stars," not "101+." Hidden-gem range narrowed to **75–99** accordingly.

2. **Adds the PR quality-check workflow** (originally drafted in #3307 but did not reach master):
   - `.github/workflows/quality-check.yml` — runs on every PR touching `README.md`.
   - `.github/scripts/quality_check.py` — extracts newly-added `github.com/OWNER/REPO` URLs from the diff and checks each one against: not archived, ≥ 100 stars (or ≥ 75 with hidden-gem justification), >1 non-bot contributor, OSI-approved license. Stale-commit shows as a ⚠️ warning (soft signal) and does not block.
   - Comments on the PR with a per-rule breakdown and fails the check if any hard rule is violated. Re-runs edit the existing comment in place.

## Test plan

- [ ] On this PR, verify the workflow itself runs (no README changes, so expect "✅ no new repositories added").
- [ ] Open a follow-up test PR adding `apple/swift-algorithms` (passes) and `hyugit/UInt256` (24 stars — fails) to verify the ✅ / ❌ paths end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)