### PR TITLE
Add Lumox to deployment and distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [Rollout.io](https://rollout.io/) - SDK to patch, fix bugs, modify and manipulate native apps (Obj-c & Swift) in real-time.
 - [AppLaunchpad](https://theapplaunchpad.com/) - Free App Store screenshot builder.
 - [LaunchKit](https://github.com/LaunchKit/LaunchKit) - A set of web-based tools for mobile app developers, now open source!
+- [Lumox](https://lumox.app) - QuickTime Alternative: Create stunning product demos and tutorials for your mobile apps.
 - [Instabug](https://instabug.com) - In-app feedback, Bug and Crash reporting, Fix Bugs Faster through user-steps, video recordings, screen annotation, network requests logging.
 - [Appfigurate](https://github.com/electricbolt/appfiguratesdk) - Secure runtime configuration for iOS and watchOS, apps and app extensions.
 - [ScreenshotFramer](https://github.com/IdeasOnCanvas/ScreenshotFramer) - With Screenshot Framer you can easily create nice-looking and localized App Store Images.


### PR DESCRIPTION
## Summary
- Add [Lumox](https://lumox.app) — QuickTime Alternative: Create stunning product demos and tutorials for your mobile apps.

## Test plan
- [x] Entry added in the appropriate section per repo guidelines
- [x] Alphabetical order checked where required
