### PR TITLE
Add LocaleLint to Localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [Hodor](https://github.com/Aufree/Hodor) - Simple solution to localize your iOS App.
 - [IBLocalizable](https://github.com/PiXeL16/IBLocalizable) - Localize your views directly in Interface Builder with IBLocalizable.
 - [L10n-swift](https://github.com/Decybel07/L10n-swift) - Localization of an application with ability to change language "on the fly" and support for plural forms in any language.
+- [LocaleLint](https://github.com/YinsPeace/localelint) - CLI and GitHub Action that validates Xcode String Catalog and XLIFF files for missing translations, placeholder mismatches, and CLDR plural coverage.
 - [LocalizationKit](https://github.com/willpowell8/LocalizationKit_iOS) - Localization management in realtime from a web portal. Easily manage your texts and translations without redeploy and resubmission.
 - [Localize](https://github.com/andresilvagomez/Localize) - Easy tool to localize apps using JSON or Strings and of course IBDesignables with extensions for UI components.
 - [Localize-Swift](https://github.com/marmelroy/Localize-Swift) - Swift 2.0 friendly localization and i18n with in-app language switching.


### PR DESCRIPTION
Adds [LocaleLint](https://github.com/YinsPeace/localelint) to the Localization section.

LocaleLint is a CLI and GitHub Action that validates Xcode String Catalog (.xcstrings) and XLIFF files for missing translations, placeholder/format-specifier mismatches, and CLDR plural-category coverage. It fits alongside the existing validation tools in this section (locheck, Rubustrings).

- Added in alphabetical order (after L10n-swift, before LocalizationKit).
- Single-line addition, description ends with a period per the list format.
- Published on the GitHub Marketplace: https://github.com/marketplace/actions/localelint