### PR TITLE
feat: add TWZRD Agent Intel MCP server to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [EthereumKit](https://github.com/yuzushioh/EthereumKit) - EthereumKit is a free, open-source Swift framework for easily interacting with the Ethereum.
 - [Web3.swift](https://github.com/Boilertalk/Web3.swift) - Web3 library for interacting with the Ethereum blockchain.
 - [web3swift](https://github.com/web3swift-team/web3swift) - Elegant Web3js functionality in Swift. Native ABI parsing and smart contract interactions.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agents on Solana. Verify agent wallet identity before x402 micropayments.
 
 **[back to top](#contributing-and-collaborating)**
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — trust scoring MCP server for AI agents on Solana.

Provides on-chain trust scores for AI agent wallets on Solana. Verify agent wallet identity before x402 micropayments. Free MCP endpoint: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

Added to the **Blockchain** section alongside other Web3/blockchain tools.

**Checklist**:
- [x] Format: `- [Name](url) - Description.`
- [x] Short description, no marketing taglines
- [x] Project is live and maintained