### PR TITLE
Add AudioLivenessDetection (on-device PCM replay/liveness detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,6 +991,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 
 - [AudioBus](https://developer.audiob.us/) - Add Next Generation Live App-to-App Audio Routing.
 - [AudioKit](https://github.com/audiokit/AudioKit) - A powerful toolkit for synthesizing, processing, and analyzing sounds.
+- [AudioLivenessDetection](https://github.com/mythkiven/AudioLivenessDetection) - On-device PCM audio liveness detection in Swift — distinguish live microphone speech from recorded replay. Zero dependencies, SPM + iOS/macOS demo.
 - [AudioPlayer](https://github.com/delannoyk/AudioPlayer) - AudioPlayer is syntax and feature sugar over AVPlayer. It plays your audio files (local & remote).
 - [AudioPlayerSwift]( https://github.com/tbaranes/AudioPlayerSwift) - AudioPlayer is a simple class for playing audio in iOS, macOS and tvOS apps.
 - [Beethoven](https://github.com/vadymmarkov/Beethoven) - An audio processing Swift library for pitch detection of musical signals.


### PR DESCRIPTION
Add [AudioLivenessDetection](https://github.com/mythkiven/AudioLivenessDetection) — on-device PCM audio liveness / replay detection for iOS & macOS.

**Why include**
- Lightweight replay detection without ML models or server-side inference
- MIT licensed, CI, technical docs, CLI + iOS SwiftUI demo
- Complements VAD/ASR entries in this list (live mic vs recorded playback)

Maintainer: @mythkiven

**Note on star count:** Project is newly open-sourced. Requesting inclusion under the ecosystem-gap exception — no other Swift SPM library in awesome-ios covers on-device PCM replay/liveness detection with zero dependencies.

Made with [Cursor](https://cursor.com)