### PR TITLE
Add solid-like-a-rock to Code Quality > Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 - [AnyLint](https://github.com/Flinesoft/AnyLint) - Lint anything by combining the power of Swift & regular expressions.
 - [IBLinter](https://github.com/IBDecodable/IBLinter) - A linter tool for Interface Builder.
 - [OCLint](https://github.com/oclint/oclint) - Static code analysis tool for improving quality and reducing defects.
+- [solid-like-a-rock](https://github.com/nenadvulic/solid-like-a-rock) - Architecture linter that enforces Clean Architecture and TCA import rules using SwiftSyntax.
 - [Swiftlint](https://github.com/realm/SwiftLint) - A tool to enforce Swift style and conventions.
 
 **[back to top](#contributing-and-collaborating)**


### PR DESCRIPTION
Adds [solid-like-a-rock](https://github.com/nenadvulic/solid-like-a-rock) to **Code Quality → Linter**, alphabetically between OCLint and Swiftlint.

> Architecture linter that enforces Clean Architecture and TCA import rules using SwiftSyntax.

It parses Swift sources with SwiftSyntax to enforce module import boundaries — Clean Architecture layers (dependencies point inward) and The Composable Architecture peer isolation — as a CI-ready guardrail. Sits alongside SwiftLint/OCLint as a dev tool: open source (MIT), Swift 6, actively maintained, on Swift Package Index and Homebrew.

- Entry placed alphabetically in the existing Linter section.
- Description follows the list format (sentence case, ends with a period).