### PR TITLE
Add Screenshot Resizer (free browser tool for App Store screenshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 
 - [Apple Review Guidelines](https://developer.apple.com/app-store/review/#common-app-rejections) - Highlighted some of the most common issues that cause apps to get rejected.
 - [Free App Store Optimization Tool](https://www.mobileaction.co) - Lets you track your App Store visibility in terms of keywords and competitors.
+- [Screenshot Resizer](https://screenshotresizer.com/) - Resize iPhone and iPad screenshots to App Store Connect sizes, add device frames and text, in the browser.
 
 **[back to top](#contributing-and-collaborating)**
 


### PR DESCRIPTION
Adds Screenshot Resizer to the App Store section. It's a free browser tool that resizes iPhone/iPad screenshots to App Store Connect dimensions, applies device frames, and adds marketing text. Runs entirely client-side — no uploads, no signup. Fits alongside the existing App Store submission/ASO tools listed here.

Patrick