### PR TITLE
Add App Store Screenshot Sizes 2026 (every Apple device dimension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Please see [CONTRIBUTING](https://github.com/vsouza/awesome-ios/blob/master/.git
 
 - [Apple Review Guidelines](https://developer.apple.com/app-store/review/#common-app-rejections) - Highlighted some of the most common issues that cause apps to get rejected.
 - [Free App Store Optimization Tool](https://www.mobileaction.co) - Lets you track your App Store visibility in terms of keywords and competitors.
+- [App Store Screenshot Sizes 2026](https://shotlingo.com/tools/app-store-screenshot-sizes) - Every iPhone, iPad, Watch, Mac, Apple TV and Vision Pro screenshot dimension in one sortable reference with copy-to-clipboard pixel values, JSON/CSV download, and a `Last verified against App Store Connect` stamp.
 
 **[back to top](#contributing-and-collaborating)**
 


### PR DESCRIPTION
Adds a free reference under **App Store**.

[App Store Screenshot Sizes 2026](https://shotlingo.com/tools/app-store-screenshot-sizes) is a single-page reference for every current Apple screenshot dimension — iPhone 6.9" (1320×2868) through legacy 3.5", iPad 13" (2064×2752) through 9.7", every Apple Watch class (Ultra 3 through Series 3), Mac, Apple TV, and Apple Vision Pro.

Key features:
- Copy-to-clipboard chips on every pixel value
- "Last verified against App Store Connect on YYYY-MM-DD" stamp (2026-06-18)
- Downloadable JSON / CSV spec pack for use in build scripts / Fastfiles
- Embeddable iframe widget for blogs / wikis
- Required vs optional flag per class with Apple's auto-scaling rules explained

Single-line addition under the existing two entries in the App Store section. No promotional copy in the entry itself. Happy to adjust wording or placement.