### PR TITLE
Add podium-mcp to Debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Check out our premium resources for further learning:
 - [Playbook](https://github.com/playbook-ui/playbook-ios) - A library for isolated developing UI components and automatically snapshots of them.
 - [PonyDebugger](https://github.com/square/PonyDebugger) - Remote network and data debugging for your native iOS app using Chrome Developer Tools.
 - [Scyther](https://github.com/bstillitano/Scyther) - A full-featured, in-app debugging menu packed full of useful tools including network logging, layout inspection, location spoofing, console logging and so much more.
+- [podium-mcp](https://github.com/hoainho/podium-mcp) - MCP server for iOS simulator and real device automation. 51 tools including simctl/devicectl lifecycle, native UI inspection, WebView DOM + network capture, and canvas/WebGL automation. Single stdio endpoint for AI agents.
 - [Woodpecker](http://www.woodpeck.cn) - View sandbox files, UserDefaults, network request from Mac.
 - [Wormholy](https://github.com/pmusolino/Wormholy) - iOS network debugging, like a wizard.
 - [Xniffer](https://github.com/xmartlabs/Xniffer) - A swift network profiler built on top of URLSession.


### PR DESCRIPTION
## Summary

Add [podium-mcp](https://github.com/hoainho/podium-mcp) to the Debugging section.

**podium-mcp** is an MCP server for iOS simulator and real device automation:
- simctl/devicectl lifecycle management
- Native UI inspection and gestures
- WebView DOM + network capture (WKWebView)
- React Native/Metro debugging over CDP
- Canvas/WebGL automation (no-vision)

Single stdio endpoint for AI agents. ~5x fewer tokens than screenshot/vision loops.

## Checklist
- [x] Entry follows the existing format
- [x] Project is a debugging/automation tool for iOS
- [x] Repository is public and actively maintained